### PR TITLE
feat: Add cache auto-purge and `--old` arg to cache clean command

### DIFF
--- a/extra/completions/_stackablectl
+++ b/extra/completions/_stackablectl
@@ -651,6 +651,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (clean)
 _arguments "${_arguments_options[@]}" \
+'--old[Only remove outdated files in the cache]' \
+'--outdated[Only remove outdated files in the cache]' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \

--- a/extra/completions/stackablectl.bash
+++ b/extra/completions/stackablectl.bash
@@ -378,7 +378,7 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__cache__clean)
-            opts="-h -V --help --version"
+            opts="-h -V --outdated --old --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/extra/completions/stackablectl.fish
+++ b/extra/completions/stackablectl.fish
@@ -159,6 +159,7 @@ complete -c stackablectl -n "__fish_seen_subcommand_from cache; and not __fish_s
 complete -c stackablectl -n "__fish_seen_subcommand_from cache; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from clean; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c stackablectl -n "__fish_seen_subcommand_from cache; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help'
 complete -c stackablectl -n "__fish_seen_subcommand_from cache; and __fish_seen_subcommand_from list" -s V -l version -d 'Print version'
+complete -c stackablectl -n "__fish_seen_subcommand_from cache; and __fish_seen_subcommand_from clean" -l old -l outdated -d 'Only remove outdated files in the cache'
 complete -c stackablectl -n "__fish_seen_subcommand_from cache; and __fish_seen_subcommand_from clean" -s h -l help -d 'Print help'
 complete -c stackablectl -n "__fish_seen_subcommand_from cache; and __fish_seen_subcommand_from clean" -s V -l version -d 'Print version'
 complete -c stackablectl -n "__fish_seen_subcommand_from cache; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from list; and not __fish_seen_subcommand_from clean; and not __fish_seen_subcommand_from help" -f -a "list" -d 'List cached files'

--- a/rust/stackable-cockpit/src/constants.rs
+++ b/rust/stackable-cockpit/src/constants.rs
@@ -8,7 +8,10 @@ pub const DEFAULT_NAMESPACE: &str = "default";
 
 pub const DEFAULT_LOCAL_CLUSTER_NAME: &str = "stackable-data-platform";
 
+pub const DEFAULT_AUTO_PURGE_INTERVAL: Duration = Duration::from_secs(60 * 15); // 15 minutes
 pub const DEFAULT_CACHE_MAX_AGE: Duration = Duration::from_secs(60 * 60); // One hour
+pub const CACHE_LAST_AUTO_PURGE_FILEPATH: &str = ".cache-last-purge";
+pub const CACHE_PROTECTED_FILES: &[&str] = &[".cache-last-purge"];
 
 pub const HELM_REPO_NAME_STABLE: &str = "stackable-stable";
 pub const HELM_REPO_NAME_TEST: &str = "stackable-test";

--- a/rust/stackable-cockpit/src/xfer/cache.rs
+++ b/rust/stackable-cockpit/src/xfer/cache.rs
@@ -298,9 +298,12 @@ pub enum DeleteFilter {
     OnlyExpired,
 }
 
-impl From<bool> for DeleteFilter {
-    fn from(value: bool) -> Self {
-        if value {
+impl DeleteFilter {
+    /// Create a [`DeleteFilter`] based on the provided boolean value. Returns
+    /// [`DeleteFilter::OnlyExpired`] when `only_expired` is `true`, otherwise
+    /// [`DeleteFilter::All`].
+    pub fn from_bool(only_expired: bool) -> Self {
+        if only_expired {
             Self::OnlyExpired
         } else {
             Self::All

--- a/rust/stackable-cockpit/src/xfer/mod.rs
+++ b/rust/stackable-cockpit/src/xfer/mod.rs
@@ -53,6 +53,11 @@ impl FileTransferClient {
         Ok(Self { client, cache })
     }
 
+    pub fn new_with(cache: Cache) -> Self {
+        let client = reqwest::Client::new();
+        Self { client, cache }
+    }
+
     /// Retrieves data from `path_or_url` which can either be a [`PathBuf`]
     /// or a [`Url`]. The `processor` defines how the data is processed, for
     /// example as plain text data, YAML content or even templated.

--- a/rust/stackablectl/src/cmds/cache.rs
+++ b/rust/stackablectl/src/cmds/cache.rs
@@ -84,10 +84,12 @@ async fn list_cmd(cache: Cache) -> Result<String, CacheCmdError> {
 async fn clean_cmd(args: &CacheCleanArgs, cache: Cache) -> Result<String, CacheCmdError> {
     info!("Cleaning cached files");
 
-    cache
-        .purge(DeleteFilter::from_bool(args.only_remove_old_files))
-        .await
-        .context(CacheSnafu)?;
+    let delete_filter = if args.only_remove_old_files {
+        DeleteFilter::OnlyExpired
+    } else {
+        DeleteFilter::All
+    };
 
+    cache.purge(delete_filter).await.context(CacheSnafu)?;
     Ok("Cleaned cached files".into())
 }

--- a/rust/stackablectl/src/cmds/cache.rs
+++ b/rust/stackablectl/src/cmds/cache.rs
@@ -85,7 +85,7 @@ async fn clean_cmd(args: &CacheCleanArgs, cache: Cache) -> Result<String, CacheC
     info!("Cleaning cached files");
 
     cache
-        .purge(args.only_remove_old_files)
+        .purge(args.only_remove_old_files.into())
         .await
         .context(CacheSnafu)?;
 

--- a/rust/stackablectl/src/cmds/cache.rs
+++ b/rust/stackablectl/src/cmds/cache.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use clap::{Args, Subcommand};
 use comfy_table::{presets::UTF8_FULL, ColumnConstraint, Table, Width};
 use snafu::{ResultExt, Snafu};
-use stackable_cockpit::xfer::cache::{self, Cache};
+use stackable_cockpit::xfer::cache::{self, Cache, DeleteFilter};
 use tracing::{info, instrument};
 
 use crate::cli::CacheSettingsError;
@@ -85,7 +85,7 @@ async fn clean_cmd(args: &CacheCleanArgs, cache: Cache) -> Result<String, CacheC
     info!("Cleaning cached files");
 
     cache
-        .purge(args.only_remove_old_files.into())
+        .purge(DeleteFilter::from_bool(args.only_remove_old_files))
         .await
         .context(CacheSnafu)?;
 

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -10,10 +10,10 @@ use stackable_cockpit::{
     common::ListError,
     platform::release::{ReleaseInstallError, ReleaseList, ReleaseUninstallError},
     utils::path::PathOrUrlParseError,
-    xfer::{FileTransferClient, FileTransferError},
+    xfer::{cache::Cache, FileTransferClient, FileTransferError},
 };
 
-use crate::cli::{CacheSettingsError, Cli, CommonClusterArgs, CommonClusterArgsError, OutputType};
+use crate::cli::{Cli, CommonClusterArgs, CommonClusterArgsError, OutputType};
 
 #[derive(Debug, Args)]
 pub struct ReleaseArgs {
@@ -91,9 +91,6 @@ pub enum ReleaseCmdError {
     #[snafu(display("path/url parse error"))]
     PathOrUrlParseError { source: PathOrUrlParseError },
 
-    #[snafu(display("cache settings resolution error"), context(false))]
-    CacheSettingsError { source: CacheSettingsError },
-
     #[snafu(display("list error"))]
     ListError { source: ListError },
 
@@ -111,12 +108,10 @@ pub enum ReleaseCmdError {
 }
 
 impl ReleaseArgs {
-    pub async fn run(&self, common_args: &Cli) -> Result<String, ReleaseCmdError> {
+    pub async fn run(&self, common_args: &Cli, cache: Cache) -> Result<String, ReleaseCmdError> {
         debug!("Handle release args");
 
-        let transfer_client = FileTransferClient::new(common_args.cache_settings()?)
-            .await
-            .context(TransferSnafu)?;
+        let transfer_client = FileTransferClient::new_with(cache);
 
         let files = common_args
             .get_release_files()

--- a/rust/stackablectl/src/main.rs
+++ b/rust/stackablectl/src/main.rs
@@ -78,14 +78,24 @@ async fn main() -> Result<(), CliError> {
         eprintln!("{err}")
     };
 
+    let cache = cli
+        .cache_settings()
+        .unwrap()
+        .try_into_cache()
+        .await
+        .unwrap();
+
+    // TODO (Techassi): Do we still want to auto purge when running cache commands?
+    cache.auto_purge().await.unwrap();
+
     let output = match &cli.subcommand {
         Commands::Operator(args) => args.run(&cli).await.context(OperatorSnafu)?,
-        Commands::Release(args) => args.run(&cli).await.context(ReleaseSnafu)?,
-        Commands::Stack(args) => args.run(&cli).await.context(StackSnafu)?,
+        Commands::Release(args) => args.run(&cli, cache).await.context(ReleaseSnafu)?,
+        Commands::Stack(args) => args.run(&cli, cache).await.context(StackSnafu)?,
         Commands::Stacklets(args) => args.run(&cli).await.context(StackletsSnafu)?,
-        Commands::Demo(args) => args.run(&cli).await.context(DemoSnafu)?,
+        Commands::Demo(args) => args.run(&cli, cache).await.context(DemoSnafu)?,
         Commands::Completions(args) => args.run().context(CompletionsSnafu)?,
-        Commands::Cache(args) => args.run(&cli).await.context(CacheSnafu)?,
+        Commands::Cache(args) => args.run(cache).await.context(CacheSnafu)?,
     };
 
     println!("{output}");


### PR DESCRIPTION
This PR adds a cache auto-purge feature, which cleans up cached files which are outdated. This is run even if the operation doesn't need cached (or remote) files. This helps to keep the cache folder clean.

The PR also adds `--old / --outdated` to the `stackablectl cache clean` command to only clear cached files which are outdated. Before this change, all cached files (even files not considered outdated) were deleted.