### PR TITLE
feat(ctl): Support `--helm-repo-multiarch`

### DIFF
--- a/extra/completions/_stackablectl
+++ b/extra/completions/_stackablectl
@@ -28,6 +28,7 @@ _stackablectl() {
 '--helm-repo-stable=[Provide a custom Helm stable repository URL]:URL:_urls' \
 '--helm-repo-test=[Provide a custom Helm test repository URL]:URL:_urls' \
 '--helm-repo-dev=[Provide a custom Helm dev repository URL]:URL:_urls' \
+'--helm-repo-multiarch=[Provide a custom Helm multiarch repository URL]:URL:_urls' \
 '--no-cache[Do not cache the remote (default) demo, stack and release files]' \
 '--offline[Do not request any remote files via the network]' \
 '-h[Print help (see more with '\''--help'\'')]' \

--- a/extra/completions/stackablectl.bash
+++ b/extra/completions/stackablectl.bash
@@ -298,7 +298,7 @@ _stackablectl() {
 
     case "${cmd}" in
         stackablectl)
-            opts="-l -n -d -s -r -h -V --log-level --no-cache --offline --operator-namespace --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version operator release stack stacklets demo completions cache help"
+            opts="-l -n -d -s -r -h -V --log-level --no-cache --offline --operator-namespace --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --helm-repo-multiarch --help --version operator release stack stacklets demo completions cache help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -353,6 +353,10 @@ _stackablectl() {
                     return 0
                     ;;
                 --helm-repo-dev)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --helm-repo-multiarch)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/extra/completions/stackablectl.fish
+++ b/extra/completions/stackablectl.fish
@@ -6,6 +6,7 @@ complete -c stackablectl -n "__fish_use_subcommand" -s r -l release-file -d 'Pro
 complete -c stackablectl -n "__fish_use_subcommand" -l helm-repo-stable -d 'Provide a custom Helm stable repository URL' -r -f
 complete -c stackablectl -n "__fish_use_subcommand" -l helm-repo-test -d 'Provide a custom Helm test repository URL' -r -f
 complete -c stackablectl -n "__fish_use_subcommand" -l helm-repo-dev -d 'Provide a custom Helm dev repository URL' -r -f
+complete -c stackablectl -n "__fish_use_subcommand" -l helm-repo-multiarch -d 'Provide a custom Helm multiarch repository URL' -r -f
 complete -c stackablectl -n "__fish_use_subcommand" -l no-cache -d 'Do not cache the remote (default) demo, stack and release files'
 complete -c stackablectl -n "__fish_use_subcommand" -l offline -d 'Do not request any remote files via the network'
 complete -c stackablectl -n "__fish_use_subcommand" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -4,7 +4,7 @@
 .SH NAME
 stackablectl
 .SH SYNOPSIS
-\fBstackablectl\fR [\fB\-l\fR|\fB\-\-log\-level\fR] [\fB\-\-no\-cache\fR] [\fB\-\-offline\fR] [\fB\-n\fR|\fB\-\-operator\-namespace\fR] [\fB\-d\fR|\fB\-\-demo\-file\fR] [\fB\-s\fR|\fB\-\-stack\-file\fR] [\fB\-r\fR|\fB\-\-release\-file\fR] [\fB\-\-helm\-repo\-stable\fR] [\fB\-\-helm\-repo\-test\fR] [\fB\-\-helm\-repo\-dev\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+\fBstackablectl\fR [\fB\-l\fR|\fB\-\-log\-level\fR] [\fB\-\-no\-cache\fR] [\fB\-\-offline\fR] [\fB\-n\fR|\fB\-\-operator\-namespace\fR] [\fB\-d\fR|\fB\-\-demo\-file\fR] [\fB\-s\fR|\fB\-\-stack\-file\fR] [\fB\-r\fR|\fB\-\-release\-file\fR] [\fB\-\-helm\-repo\-stable\fR] [\fB\-\-helm\-repo\-test\fR] [\fB\-\-helm\-repo\-dev\fR] [\fB\-\-helm\-repo\-multiarch\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
@@ -65,6 +65,9 @@ Provide a custom Helm test repository URL
 .TP
 \fB\-\-helm\-repo\-dev\fR=\fIURL\fR [default: https://repo.stackable.tech/repository/helm\-dev/]
 Provide a custom Helm dev repository URL
+.TP
+\fB\-\-helm\-repo\-multiarch\fR=\fIURL\fR [default: https://repo.stackable.tech/repository/helm\-experimental/]
+Provide a custom Helm multiarch repository URL
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/rust/stackable-cockpit/src/constants.rs
+++ b/rust/stackable-cockpit/src/constants.rs
@@ -13,6 +13,7 @@ pub const DEFAULT_CACHE_MAX_AGE: Duration = Duration::from_secs(60 * 60); // One
 pub const CACHE_LAST_AUTO_PURGE_FILEPATH: &str = ".cache-last-purge";
 pub const CACHE_PROTECTED_FILES: &[&str] = &[".cache-last-purge"];
 
+pub const HELM_REPO_NAME_MULTIARCH: &str = "stackable-experimental";
 pub const HELM_REPO_NAME_STABLE: &str = "stackable-stable";
 pub const HELM_REPO_NAME_TEST: &str = "stackable-test";
 pub const HELM_REPO_NAME_DEV: &str = "stackable-dev";

--- a/rust/stackablectl/README.md
+++ b/rust/stackablectl/README.md
@@ -89,6 +89,11 @@ Options:
 
           [default: https://repo.stackable.tech/repository/helm-dev/]
 
+      --helm-repo-multiarch <URL>
+          Provide a custom Helm multiarch repository URL
+
+          [default: https://repo.stackable.tech/repository/helm-experimental/]
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/rust/stackablectl/src/cli/mod.rs
+++ b/rust/stackablectl/src/cli/mod.rs
@@ -6,7 +6,8 @@ use tracing::{debug, instrument, Level};
 
 use stackable_cockpit::{
     constants::{
-        DEFAULT_NAMESPACE, HELM_REPO_NAME_DEV, HELM_REPO_NAME_STABLE, HELM_REPO_NAME_TEST,
+        DEFAULT_NAMESPACE, HELM_REPO_NAME_DEV, HELM_REPO_NAME_MULTIARCH, HELM_REPO_NAME_STABLE,
+        HELM_REPO_NAME_TEST,
     },
     helm::{self, HelmError},
     utils::path::{
@@ -22,8 +23,8 @@ use crate::{
     },
     constants::{
         CACHE_HOME_PATH, ENV_KEY_DEMO_FILES, ENV_KEY_RELEASE_FILES, ENV_KEY_STACK_FILES,
-        HELM_REPO_URL_DEV, HELM_REPO_URL_STABLE, HELM_REPO_URL_TEST, REMOTE_DEMO_FILE,
-        REMOTE_RELEASE_FILE, REMOTE_STACK_FILE,
+        HELM_REPO_URL_DEV, HELM_REPO_URL_MULTIARCH, HELM_REPO_URL_STABLE, HELM_REPO_URL_TEST,
+        REMOTE_DEMO_FILE, REMOTE_RELEASE_FILE, REMOTE_STACK_FILE,
     },
 };
 
@@ -108,6 +109,10 @@ to provide multiple additional release files.")]
     #[arg(long, value_name = "URL", value_hint = ValueHint::Url, default_value = HELM_REPO_URL_DEV)]
     pub helm_repo_dev: String,
 
+    /// Provide a custom Helm multiarch repository URL
+    #[arg(long, value_name = "URL", value_hint = ValueHint::Url, default_value = HELM_REPO_URL_MULTIARCH)]
+    pub helm_repo_multiarch: String,
+
     #[command(subcommand)]
     pub subcommand: Commands,
 }
@@ -181,6 +186,9 @@ impl Cli {
 
         // Dev repository
         helm::add_repo(HELM_REPO_NAME_DEV, &self.helm_repo_dev)?;
+
+        // Multiarch repository
+        helm::add_repo(HELM_REPO_NAME_MULTIARCH, &self.helm_repo_multiarch)?;
 
         Ok(())
     }

--- a/rust/stackablectl/src/constants.rs
+++ b/rust/stackablectl/src/constants.rs
@@ -11,6 +11,8 @@ pub const REMOTE_STACK_FILE: &str =
 pub const REMOTE_RELEASE_FILE: &str =
     "https://raw.githubusercontent.com/stackabletech/release/main/releases.yaml";
 
+pub const HELM_REPO_URL_MULTIARCH: &str =
+    "https://repo.stackable.tech/repository/helm-experimental/";
 pub const HELM_REPO_URL_STABLE: &str = "https://repo.stackable.tech/repository/helm-stable/";
 pub const HELM_REPO_URL_TEST: &str = "https://repo.stackable.tech/repository/helm-test/";
 pub const HELM_REPO_URL_DEV: &str = "https://repo.stackable.tech/repository/helm-dev/";

--- a/rust/stackablectl/src/utils.rs
+++ b/rust/stackablectl/src/utils.rs
@@ -2,10 +2,12 @@ use std::env;
 
 use snafu::Snafu;
 use stackable_cockpit::constants::{
-    HELM_REPO_NAME_DEV, HELM_REPO_NAME_STABLE, HELM_REPO_NAME_TEST,
+    HELM_REPO_NAME_DEV, HELM_REPO_NAME_MULTIARCH, HELM_REPO_NAME_STABLE, HELM_REPO_NAME_TEST,
 };
 
-use crate::constants::{HELM_REPO_URL_DEV, HELM_REPO_URL_STABLE, HELM_REPO_URL_TEST};
+use crate::constants::{
+    HELM_REPO_URL_DEV, HELM_REPO_URL_MULTIARCH, HELM_REPO_URL_STABLE, HELM_REPO_URL_TEST,
+};
 
 #[derive(Debug, Snafu)]
 #[snafu(display("Invalid Helm repo name ({name}), cannot resolve to repo URL"))]
@@ -23,6 +25,7 @@ where
     let repo_name = repo_name.as_ref();
 
     match repo_name {
+        HELM_REPO_NAME_MULTIARCH => Ok(HELM_REPO_URL_MULTIARCH),
         HELM_REPO_NAME_STABLE => Ok(HELM_REPO_URL_STABLE),
         HELM_REPO_NAME_TEST => Ok(HELM_REPO_URL_TEST),
         HELM_REPO_NAME_DEV => Ok(HELM_REPO_URL_DEV),


### PR DESCRIPTION
This PR adds support for `--helm-repo-multiarch` until we finalized multi arch support and how we want to integrate support for it in `stackablectl`.

~This PR is blocked because another PR (#79) restructures the CLI arguments.~ Not blocked anymore, because #79 is merged.