### PR TITLE
refactor: Replace `xdg` with `directories`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,12 +665,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -682,6 +691,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1639,6 +1660,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -2640,6 +2667,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "directories",
  "dotenvy",
  "indexmap 2.0.0",
  "lazy_static",
@@ -2654,7 +2682,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "xdg",
 ]
 
 [[package]]
@@ -3545,12 +3572,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "xdg"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bcrypt = "0.15"
 clap = { version = "4.2.1", features = ["derive", "env"] }
 clap_complete = "4.2"
 comfy-table = { version = "7.0", features = ["custom_styling"] }
+directories = "5.0"
 dotenvy = "0.15"
 futures = "0.3"
 gobuild = "0.1.0-alpha.2"
@@ -45,7 +46,6 @@ utoipa = { version = "3.3", features = ["indexmap"] }
 utoipa-swagger-ui = { version = "3.1", features = ["axum"] }
 uuid = { version = "1.4.0", features = ["v4"] }
 which = "4.4"
-xdg = "2.4"
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
 # TODO: Switch to released version

--- a/deny.toml
+++ b/deny.toml
@@ -31,23 +31,20 @@ allow = [
     "LicenseRef-webpki",
     "MIT",
     "Unicode-DFS-2016",
-    "Zlib"
+    "Zlib",
+    "MPL-2.0",
 ]
 private = { ignore = true }
 
 [[licenses.clarify]]
 name = "ring"
 expression = "LicenseRef-ring"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 },
-]
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [[licenses.clarify]]
 name = "webpki"
 expression = "LicenseRef-webpki"
-license-files = [
-    { path = "LICENSE", hash = 0x001c7e6c },
-]
+license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 
 [sources]
 unknown-registry = "deny"

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -14,6 +14,7 @@ stackable-cockpit = { path = "../stackable-cockpit", features = ["openapi"] }
 clap_complete.workspace = true
 clap.workspace = true
 comfy-table.workspace = true
+directories.workspace = true
 dotenvy.workspace = true
 indexmap.workspace = true
 lazy_static.workspace = true
@@ -27,4 +28,3 @@ snafu.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-xdg.workspace = true

--- a/rust/stackablectl/src/cli/mod.rs
+++ b/rust/stackablectl/src/cli/mod.rs
@@ -195,8 +195,6 @@ pub enum CacheSettingsError {
     UserDir,
 }
 
-pub struct InheritStackDemoArgs {}
-
 /// Returns a list of paths or urls based on the default (remote) file and
 /// files provided via the env variable.
 fn get_files(default_file: &str, env_key: &str) -> Result<Vec<PathOrUrl>, PathOrUrlParseError> {

--- a/rust/stackablectl/src/cli/mod.rs
+++ b/rust/stackablectl/src/cli/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     },
     constants::{
         ENV_KEY_DEMO_FILES, ENV_KEY_RELEASE_FILES, ENV_KEY_STACK_FILES, REMOTE_DEMO_FILE,
-        REMOTE_RELEASE_FILE, REMOTE_STACK_FILE, XDG_APPLICATION_NAME, XDG_ORGANIZATION_NAME,
-        XDG_QUALIFIER,
+        REMOTE_RELEASE_FILE, REMOTE_STACK_FILE, USER_DIR_APPLICATION_NAME,
+        USER_DIR_ORGANIZATION_NAME, USER_DIR_QUALIFIER,
     },
 };
 
@@ -125,9 +125,12 @@ impl Cli {
         if self.no_cache {
             Ok(CacheSettings::disabled())
         } else {
-            let project_dir =
-                ProjectDirs::from(XDG_QUALIFIER, XDG_ORGANIZATION_NAME, XDG_APPLICATION_NAME)
-                    .ok_or(CacheSettingsError::Xdg)?;
+            let project_dir = ProjectDirs::from(
+                USER_DIR_QUALIFIER,
+                USER_DIR_ORGANIZATION_NAME,
+                USER_DIR_APPLICATION_NAME,
+            )
+            .ok_or(CacheSettingsError::UserDir)?;
 
             Ok(CacheSettings::disk(project_dir.cache_dir()))
         }
@@ -188,8 +191,8 @@ pub enum OutputType {
 #[derive(Debug, Snafu)]
 #[snafu(module)]
 pub enum CacheSettingsError {
-    #[snafu(display("unable to resolve XDG directories"))]
-    Xdg,
+    #[snafu(display("unable to resolve user directories"))]
+    UserDir,
 }
 
 pub struct InheritStackDemoArgs {}

--- a/rust/stackablectl/src/constants.rs
+++ b/rust/stackablectl/src/constants.rs
@@ -15,4 +15,6 @@ pub const HELM_REPO_URL_STABLE: &str = "https://repo.stackable.tech/repository/h
 pub const HELM_REPO_URL_TEST: &str = "https://repo.stackable.tech/repository/helm-test/";
 pub const HELM_REPO_URL_DEV: &str = "https://repo.stackable.tech/repository/helm-dev/";
 
-pub const CACHE_HOME_PATH: &str = "stackablectl";
+pub const XDG_APPLICATION_NAME: &str = "stackablectl";
+pub const XDG_ORGANIZATION_NAME: &str = "Stackable";
+pub const XDG_QUALIFIER: &str = "tech";

--- a/rust/stackablectl/src/constants.rs
+++ b/rust/stackablectl/src/constants.rs
@@ -15,6 +15,6 @@ pub const HELM_REPO_URL_STABLE: &str = "https://repo.stackable.tech/repository/h
 pub const HELM_REPO_URL_TEST: &str = "https://repo.stackable.tech/repository/helm-test/";
 pub const HELM_REPO_URL_DEV: &str = "https://repo.stackable.tech/repository/helm-dev/";
 
-pub const XDG_APPLICATION_NAME: &str = "stackablectl";
-pub const XDG_ORGANIZATION_NAME: &str = "Stackable";
-pub const XDG_QUALIFIER: &str = "tech";
+pub const USER_DIR_APPLICATION_NAME: &str = "stackablectl";
+pub const USER_DIR_ORGANIZATION_NAME: &str = "Stackable";
+pub const USER_DIR_QUALIFIER: &str = "tech";

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -12,14 +12,14 @@ type OneOf<T extends any[]> = T extends [infer Only] ? Only : T extends [infer A
 export interface paths {
   "/demos": {
     /**
-     * Retrieves all demos. 
+     * Retrieves all demos.
      * @description Retrieves all demos.
      */
     get: operations["get_demos"];
   };
   "/demos/{name}": {
     /**
-     * Retrieves one demo identified by `name`. 
+     * Retrieves one demo identified by `name`.
      * @description Retrieves one demo identified by `name`.
      */
     get: operations["get_demo"];
@@ -32,21 +32,21 @@ export interface paths {
   };
   "/releases": {
     /**
-     * Retrieves all releases. 
+     * Retrieves all releases.
      * @description Retrieves all releases.
      */
     get: operations["get_releases"];
   };
   "/releases/{name}": {
     /**
-     * Retrieves one release identified by `name`. 
+     * Retrieves one release identified by `name`.
      * @description Retrieves one release identified by `name`.
      */
     get: operations["get_release"];
   };
   "/stacklets": {
     /**
-     * Retrieves all stacklets. 
+     * Retrieves all stacklets.
      * @description Retrieves all stacklets.
      */
     get: operations["get_stacklets"];
@@ -64,18 +64,18 @@ export interface components {
       /** @description An optional link to a documentation page */
       documentation?: string | null;
       /** @description A variable number of labels (tags) */
-      labels?: (string)[];
+      labels?: string[];
       /** @description A variable number of Helm or YAML manifests */
-      manifests?: (components["schemas"]["ManifestSpec"])[];
+      manifests?: components["schemas"]["ManifestSpec"][];
       /** @description A variable number of supported parameters */
-      parameters?: (components["schemas"]["Parameter"])[];
+      parameters?: components["schemas"]["Parameter"][];
       /** @description The name of the underlying stack */
       stackableStack: string;
       /**
        * @description Supported namespaces this demo can run in. An empty list indicates that
        * the demo can run in any namespace.
        */
-      supportedNamespaces?: (string)[];
+      supportedNamespaces?: string[];
     };
     DisplayCondition: {
       condition: string;
@@ -116,7 +116,7 @@ export interface components {
     SessionToken: string;
     Stacklet: {
       /** @description Multiple cluster conditions. */
-      conditions: (components["schemas"]["DisplayCondition"])[];
+      conditions: components["schemas"]["DisplayCondition"][];
       /**
        * @description Endpoint addresses the product is reachable at.
        * The key is the service name (e.g. `web-ui`), the value is the URL.
@@ -144,7 +144,7 @@ export type external = Record<string, never>;
 export interface operations {
 
   /**
-   * Retrieves all demos. 
+   * Retrieves all demos.
    * @description Retrieves all demos.
    */
   get_demos: {
@@ -152,15 +152,17 @@ export interface operations {
       /** @description Retrieving a list of demos succeeded */
       200: {
         content: {
-          "application/json": (components["schemas"]["DemoSpecV2"])[];
+          "application/json": components["schemas"]["DemoSpecV2"][];
         };
       };
       /** @description Retrieving a list of demos failed */
-      404: never;
+      404: {
+        content: never;
+      };
     };
   };
   /**
-   * Retrieves one demo identified by `name`. 
+   * Retrieves one demo identified by `name`.
    * @description Retrieves one demo identified by `name`.
    */
   get_demo: {
@@ -172,7 +174,9 @@ export interface operations {
         };
       };
       /** @description Retrieving the demo with 'name' failed */
-      404: never;
+      404: {
+        content: never;
+      };
     };
   };
   log_in: {
@@ -199,7 +203,7 @@ export interface operations {
     };
   };
   /**
-   * Retrieves all releases. 
+   * Retrieves all releases.
    * @description Retrieves all releases.
    */
   get_releases: {
@@ -207,15 +211,17 @@ export interface operations {
       /** @description Retrieving a list of releases succeeded */
       200: {
         content: {
-          "application/json": (components["schemas"]["ReleaseSpec"])[];
+          "application/json": components["schemas"]["ReleaseSpec"][];
         };
       };
       /** @description Retrieving a list of releases failed */
-      404: never;
+      404: {
+        content: never;
+      };
     };
   };
   /**
-   * Retrieves one release identified by `name`. 
+   * Retrieves one release identified by `name`.
    * @description Retrieves one release identified by `name`.
    */
   get_release: {
@@ -223,14 +229,14 @@ export interface operations {
     };
   };
   /**
-   * Retrieves all stacklets. 
+   * Retrieves all stacklets.
    * @description Retrieves all stacklets.
    */
   get_stacklets: {
     responses: {
       200: {
         content: {
-          "application/json": (components["schemas"]["Stacklet"])[];
+          "application/json": components["schemas"]["Stacklet"][];
         };
       };
     };


### PR DESCRIPTION
This is a drop-in replacement. Using `directories` enables us to build `stackablectl` for Windows as `xdg` didn't support Windows.