### PR TITLE
fix(ctl): Skip creating operator-namespace when passing `--skip-release` in stack/demo command

### DIFF
--- a/rust/stackable-cockpit/src/platform/demo/spec.rs
+++ b/rust/stackable-cockpit/src/platform/demo/spec.rs
@@ -136,16 +136,13 @@ impl DemoSpecV2 {
             .context(StackSnafu)?;
         self.check_prerequisites(product_namespace).await?;
 
-        // Install release
-        stack_spec
-            .install_release(
-                release_list,
-                operator_namespace,
-                product_namespace,
-                skip_release,
-            )
-            .await
-            .context(StackSnafu)?;
+        // Install release if not opted out
+        if !skip_release {
+            stack_spec
+                .install_release(release_list, operator_namespace, product_namespace)
+                .await
+                .context(StackSnafu)?;
+        }
 
         // Install stack
         stack_spec

--- a/rust/stackable-cockpit/src/platform/stack/spec.rs
+++ b/rust/stackable-cockpit/src/platform/stack/spec.rs
@@ -159,14 +159,8 @@ impl StackSpecV2 {
         release_list: ReleaseList,
         operator_namespace: &str,
         product_namespace: &str,
-        skip_release_install: bool,
     ) -> Result<(), StackError> {
         info!("Installing release for stack");
-
-        if skip_release_install {
-            info!("Skipping release installation during stack installation process");
-            return Ok(());
-        }
 
         // Get the release by name
         let release = release_list

--- a/rust/stackable-cockpit/src/platform/stack/spec.rs
+++ b/rust/stackable-cockpit/src/platform/stack/spec.rs
@@ -160,7 +160,7 @@ impl StackSpecV2 {
         operator_namespace: &str,
         product_namespace: &str,
     ) -> Result<(), StackError> {
-        info!("Installing release for stack");
+        info!("Trying to install release {}", self.release);
 
         // Get the release by name
         let release = release_list

--- a/rust/stackablectl/src/cmds/demo.rs
+++ b/rust/stackablectl/src/cmds/demo.rs
@@ -275,17 +275,19 @@ async fn install_cmd(
         .clone()
         .unwrap_or(DEFAULT_OPERATOR_NAMESPACE.into());
 
-    namespace::create_if_needed(operator_namespace.clone())
-        .await
-        .context(NamespaceSnafu {
-            namespace: operator_namespace.clone(),
-        })?;
-
     let product_namespace = args
         .namespaces
         .product_namespace
         .clone()
         .unwrap_or(DEFAULT_PRODUCT_NAMESPACE.into());
+
+    if !args.skip_release {
+        namespace::create_if_needed(operator_namespace.clone())
+            .await
+            .context(NamespaceSnafu {
+                namespace: operator_namespace.clone(),
+            })?;
+    }
 
     namespace::create_if_needed(product_namespace.clone())
         .await

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -9,7 +9,10 @@ use tracing::{debug, info, instrument};
 use stackable_cockpit::{
     common::ListError,
     constants::DEFAULT_OPERATOR_NAMESPACE,
-    platform::release::{ReleaseInstallError, ReleaseList, ReleaseUninstallError},
+    platform::{
+        namespace::{self, NamespaceError},
+        release::{ReleaseInstallError, ReleaseList, ReleaseUninstallError},
+    },
     utils::path::PathOrUrlParseError,
     xfer::{cache::Cache, FileTransferClient, FileTransferError},
 };
@@ -117,6 +120,12 @@ pub enum ReleaseCmdError {
 
     #[snafu(display("transfer error"))]
     TransferError { source: FileTransferError },
+
+    #[snafu(display("failed to create namespace '{namespace}'"))]
+    NamespaceError {
+        source: NamespaceError,
+        namespace: String,
+    },
 }
 
 impl ReleaseArgs {
@@ -235,14 +244,21 @@ async fn install_cmd(
 ) -> Result<String, ReleaseCmdError> {
     info!("Installing release");
 
-    // Install local cluster if needed
-    args.local_cluster
-        .install_if_needed(None)
-        .await
-        .context(CommonClusterArgsSnafu)?;
-
     match release_list.get(&args.release) {
         Some(release) => {
+            // Install local cluster if needed
+            args.local_cluster
+                .install_if_needed(None)
+                .await
+                .context(CommonClusterArgsSnafu)?;
+
+            // Create operator namespace if needed
+            namespace::create_if_needed(args.operator_namespace.clone())
+                .await
+                .context(NamespaceSnafu {
+                    namespace: args.operator_namespace.clone(),
+                })?;
+
             release
                 .install(
                     &args.included_products,
@@ -251,7 +267,7 @@ async fn install_cmd(
                 )
                 .context(ReleaseInstallSnafu)?;
 
-            Ok("Installed release".into())
+            Ok(format!("Installed release {}", args.release))
         }
         None => Ok("No such release".into()),
     }
@@ -261,7 +277,7 @@ async fn uninstall_cmd(
     args: &ReleaseUninstallArgs,
     release_list: ReleaseList,
 ) -> Result<String, ReleaseCmdError> {
-    info!("Installing release");
+    info!("Uninstalling release");
 
     match release_list.get(&args.release) {
         Some(release) => {
@@ -269,7 +285,7 @@ async fn uninstall_cmd(
                 .uninstall(&args.operator_namespace)
                 .context(ReleaseUninstallSnafu)?;
 
-            Ok("Installed release".into())
+            Ok(format!("Uninstalled release {}", args.release))
         }
         None => Ok("No such release".into()),
     }

--- a/rust/stackablectl/src/cmds/stack.rs
+++ b/rust/stackablectl/src/cmds/stack.rs
@@ -242,11 +242,11 @@ async fn install_cmd(
         .await
         .context(ListSnafu)?;
 
-    // Install local cluster if needed
-    args.local_cluster
-        .install_if_needed(None)
-        .await
-        .context(CommonClusterArgsSnafu)?;
+    let product_namespace = args
+        .namespaces
+        .product_namespace
+        .clone()
+        .unwrap_or(DEFAULT_PRODUCT_NAMESPACE.into());
 
     let operator_namespace = args
         .namespaces
@@ -254,42 +254,42 @@ async fn install_cmd(
         .clone()
         .unwrap_or(DEFAULT_OPERATOR_NAMESPACE.into());
 
-    namespace::create_if_needed(operator_namespace.clone())
-        .await
-        .context(NamespaceSnafu {
-            namespace: operator_namespace.clone(),
-        })?;
-
-    let product_namespace = args
-        .namespaces
-        .product_namespace
-        .clone()
-        .unwrap_or(DEFAULT_PRODUCT_NAMESPACE.into());
-
-    namespace::create_if_needed(product_namespace.clone())
-        .await
-        .context(NamespaceSnafu {
-            namespace: product_namespace.clone(),
-        })?;
-
     match stack_list.get(&args.stack_name) {
         Some(stack_spec) => {
+            // Install local cluster if needed
+            args.local_cluster
+                .install_if_needed(None)
+                .await
+                .context(CommonClusterArgsSnafu)?;
+
             // Check perquisites
             stack_spec
                 .check_prerequisites(&product_namespace)
                 .await
                 .context(StackSnafu)?;
 
-            // Install release
-            stack_spec
-                .install_release(
-                    release_list,
-                    &operator_namespace,
-                    &product_namespace,
-                    args.skip_release,
-                )
+            // Install release if not opted out
+            if !args.skip_release {
+                namespace::create_if_needed(operator_namespace.clone())
+                    .await
+                    .context(NamespaceSnafu {
+                        namespace: operator_namespace.clone(),
+                    })?;
+
+                stack_spec
+                    .install_release(release_list, &operator_namespace, &product_namespace)
+                    .await
+                    .context(StackSnafu)?;
+            } else {
+                info!("Skipping release installation during stack installation process");
+            }
+
+            // Create product namespace if needed
+            namespace::create_if_needed(product_namespace.clone())
                 .await
-                .context(StackSnafu)?;
+                .context(NamespaceSnafu {
+                    namespace: product_namespace.clone(),
+                })?;
 
             // Install stack
             stack_spec


### PR DESCRIPTION
Discovered by @sbernauer, brought forward in Slack chat.