### PR TITLE
fix: The `completions` subcommand now works without internet access

### DIFF
--- a/rust/stackablectl/src/cli/mod.rs
+++ b/rust/stackablectl/src/cli/mod.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use directories::ProjectDirs;
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
 use tracing::{debug, instrument, Level};
 
 use stackable_cockpit::{
@@ -17,16 +17,40 @@ use stackable_cockpit::{
 
 use crate::{
     args::{CommonFileArgs, CommonRepoArgs},
-    cmds::{
-        cache::CacheArgs, completions::CompletionsArgs, demo::DemoArgs, operator::OperatorArgs,
-        release::ReleaseArgs, stack::StackArgs, stacklets::StackletsArgs,
-    },
+    cmds::{cache, completions, demo, operator, release, stack, stacklets},
     constants::{
         ENV_KEY_DEMO_FILES, ENV_KEY_RELEASE_FILES, ENV_KEY_STACK_FILES, REMOTE_DEMO_FILE,
         REMOTE_RELEASE_FILE, REMOTE_STACK_FILE, USER_DIR_APPLICATION_NAME,
         USER_DIR_ORGANIZATION_NAME, USER_DIR_QUALIFIER,
     },
 };
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("operator command error"))]
+    Operator { source: operator::CmdError },
+
+    #[snafu(display("release command error"))]
+    Release { source: release::CmdError },
+
+    #[snafu(display("stack command error"))]
+    Stack { source: stack::CmdError },
+
+    #[snafu(display("stacklets command error"))]
+    Stacklets { source: stacklets::CmdError },
+
+    #[snafu(display("demo command error"))]
+    Demo { source: demo::CmdError },
+
+    #[snafu(display("completions command error"))]
+    Completions { source: completions::CmdError },
+
+    #[snafu(display("cache command error"))]
+    Cache { source: cache::CmdError },
+
+    #[snafu(display("helm error"))]
+    Helm { source: HelmError },
+}
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, propagate_version = true)]
@@ -135,21 +159,54 @@ impl Cli {
             Ok(CacheSettings::disk(project_dir.cache_dir()))
         }
     }
+
+    #[instrument]
+    pub async fn run(&self) -> Result<String, Error> {
+        // FIXME (Techassi): There might be a better way to handle this with
+        // the match later in this function.
+
+        // Add Helm repos only when required
+        match &self.subcommand {
+            Commands::Completions(_) => (),
+            Commands::Cache(_) => (),
+            _ => self.add_helm_repos().context(HelmSnafu)?,
+        }
+
+        let cache = self
+            .cache_settings()
+            .unwrap()
+            .try_into_cache()
+            .await
+            .unwrap();
+
+        // TODO (Techassi): Do we still want to auto purge when running cache commands?
+        cache.auto_purge().await.unwrap();
+
+        match &self.subcommand {
+            Commands::Operator(args) => args.run(self).await.context(OperatorSnafu),
+            Commands::Release(args) => args.run(self, cache).await.context(ReleaseSnafu),
+            Commands::Stack(args) => args.run(self, cache).await.context(StackSnafu),
+            Commands::Stacklets(args) => args.run(self).await.context(StackletsSnafu),
+            Commands::Demo(args) => args.run(self, cache).await.context(DemoSnafu),
+            Commands::Completions(args) => args.run().context(CompletionsSnafu),
+            Commands::Cache(args) => args.run(cache).await.context(CacheSnafu),
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     /// Interact with single operator instead of the full platform
     #[command(alias("op"))]
-    Operator(OperatorArgs),
+    Operator(operator::OperatorArgs),
 
     /// Interact with all operators of the platform which are released together
     #[command(alias("re"))]
-    Release(ReleaseArgs),
+    Release(release::ReleaseArgs),
 
     /// Interact with stacks, which are ready-to-use product combinations
     #[command(alias("st"))]
-    Stack(StackArgs),
+    Stack(stack::StackArgs),
 
     /// Interact with deployed stacklets, which are bundles of resources and
     /// containers required to run the product.
@@ -162,17 +219,17 @@ Each stacklet consists of init containers, app containers, sidecar containers
 and additional Kubernetes resources like StatefulSets, ConfigMaps, Services and
 CRDs."
     )]
-    Stacklets(StackletsArgs),
+    Stacklets(stacklets::StackletsArgs),
 
     /// Interact with demos, which are end-to-end usage demonstrations of the Stackable data platform
-    Demo(DemoArgs),
+    Demo(demo::DemoArgs),
 
     /// Generate shell completions for this tool
     #[command(alias("comp"))]
-    Completions(CompletionsArgs),
+    Completions(completions::CompletionsArgs),
 
     /// Interact with locally cached files
-    Cache(CacheArgs),
+    Cache(cache::CacheArgs),
 }
 
 #[derive(Clone, Debug, Default, ValueEnum)]

--- a/rust/stackablectl/src/cmds/cache.rs
+++ b/rust/stackablectl/src/cmds/cache.rs
@@ -33,7 +33,7 @@ pub struct CacheCleanArgs {
 }
 
 #[derive(Debug, Snafu)]
-pub enum CacheCmdError {
+pub enum CmdError {
     #[snafu(display("cache settings error"))]
     CacheSettingsError { source: CacheSettingsError },
 
@@ -42,7 +42,7 @@ pub enum CacheCmdError {
 }
 
 impl CacheArgs {
-    pub async fn run(&self, cache: Cache) -> Result<String, CacheCmdError> {
+    pub async fn run(&self, cache: Cache) -> Result<String, CmdError> {
         match &self.subcommand {
             CacheCommands::List => list_cmd(cache).await,
             CacheCommands::Clean(args) => clean_cmd(args, cache).await,
@@ -51,7 +51,7 @@ impl CacheArgs {
 }
 
 #[instrument(skip_all)]
-async fn list_cmd(cache: Cache) -> Result<String, CacheCmdError> {
+async fn list_cmd(cache: Cache) -> Result<String, CmdError> {
     info!("Listing cached files");
 
     let files = cache.list().await.context(CacheSnafu)?;
@@ -81,7 +81,7 @@ async fn list_cmd(cache: Cache) -> Result<String, CacheCmdError> {
 }
 
 #[instrument(skip_all)]
-async fn clean_cmd(args: &CacheCleanArgs, cache: Cache) -> Result<String, CacheCmdError> {
+async fn clean_cmd(args: &CacheCleanArgs, cache: Cache) -> Result<String, CmdError> {
     info!("Cleaning cached files");
 
     let delete_filter = if args.only_remove_old_files {

--- a/rust/stackablectl/src/cmds/completions.rs
+++ b/rust/stackablectl/src/cmds/completions.rs
@@ -23,13 +23,13 @@ pub enum CompletionCommands {
 }
 
 #[derive(Debug, Snafu)]
-pub enum CompletionsCmdError {
+pub enum CmdError {
     #[snafu(display("string error: {source}"))]
     StringError { source: std::string::FromUtf8Error },
 }
 
 impl CompletionsArgs {
-    pub fn run(&self) -> Result<String, CompletionsCmdError> {
+    pub fn run(&self) -> Result<String, CmdError> {
         match &self.subcommand {
             CompletionCommands::Bash => generate_completions(Shell::Bash),
             CompletionCommands::Fish => generate_completions(Shell::Fish),
@@ -38,7 +38,7 @@ impl CompletionsArgs {
     }
 }
 
-fn generate_completions(shell: Shell) -> Result<String, CompletionsCmdError> {
+fn generate_completions(shell: Shell) -> Result<String, CmdError> {
     let mut cmd = Cli::command();
     let mut buf = Vec::new();
 

--- a/rust/stackablectl/src/cmds/demo.rs
+++ b/rust/stackablectl/src/cmds/demo.rs
@@ -111,7 +111,7 @@ to specify operator versions."
 pub struct DemoUninstallArgs {}
 
 #[derive(Debug, Snafu)]
-pub enum DemoCmdError {
+pub enum CmdError {
     #[snafu(display("unable to format yaml output"))]
     YamlOutputFormatError { source: serde_yaml::Error },
 
@@ -148,7 +148,7 @@ pub enum DemoCmdError {
 
 impl DemoArgs {
     #[instrument]
-    pub async fn run(&self, common_args: &Cli, cache: Cache) -> Result<String, DemoCmdError> {
+    pub async fn run(&self, common_args: &Cli, cache: Cache) -> Result<String, CmdError> {
         debug!("Handle demo args");
 
         let transfer_client = FileTransferClient::new_with(cache);
@@ -173,7 +173,7 @@ impl DemoArgs {
 
 /// Print out a list of demos, either as a table (plain), JSON or YAML
 #[instrument]
-async fn list_cmd(args: &DemoListArgs, list: DemoList) -> Result<String, DemoCmdError> {
+async fn list_cmd(args: &DemoListArgs, list: DemoList) -> Result<String, CmdError> {
     info!("Listing demos");
 
     match args.output_type {
@@ -204,10 +204,10 @@ async fn list_cmd(args: &DemoListArgs, list: DemoList) -> Result<String, DemoCmd
 
 /// Describe a specific demo by printing out a table (plain), JSON or YAML
 #[instrument]
-async fn describe_cmd(args: &DemoDescribeArgs, list: DemoList) -> Result<String, DemoCmdError> {
+async fn describe_cmd(args: &DemoDescribeArgs, list: DemoList) -> Result<String, CmdError> {
     info!("Describing demo {}", args.demo_name);
 
-    let demo = list.get(&args.demo_name).ok_or(DemoCmdError::NoSuchDemo {
+    let demo = list.get(&args.demo_name).ok_or(CmdError::NoSuchDemo {
         name: args.demo_name.clone(),
     })?;
 
@@ -242,10 +242,10 @@ async fn install_cmd(
     common_args: &Cli,
     list: DemoList,
     transfer_client: &FileTransferClient,
-) -> Result<String, DemoCmdError> {
+) -> Result<String, CmdError> {
     info!("Installing demo {}", args.demo_name);
 
-    let demo_spec = list.get(&args.demo_name).ok_or(DemoCmdError::NoSuchDemo {
+    let demo_spec = list.get(&args.demo_name).ok_or(CmdError::NoSuchDemo {
         name: args.demo_name.clone(),
     })?;
 

--- a/rust/stackablectl/src/cmds/operator.rs
+++ b/rust/stackablectl/src/cmds/operator.rs
@@ -122,7 +122,7 @@ pub struct OperatorInstalledArgs {
 }
 
 #[derive(Debug, Snafu)]
-pub enum OperatorCmdError {
+pub enum CmdError {
     #[snafu(display("invalid repo name"))]
     InvalidRepoNameError { source: InvalidRepoNameError },
 
@@ -158,7 +158,7 @@ pub enum OperatorCmdError {
 pub struct OperatorVersionList(HashMap<String, Vec<String>>);
 
 impl OperatorArgs {
-    pub async fn run(&self, common_args: &Cli) -> Result<String, OperatorCmdError> {
+    pub async fn run(&self, common_args: &Cli) -> Result<String, CmdError> {
         match &self.subcommand {
             OperatorCommands::List(args) => list_cmd(args, common_args).await,
             OperatorCommands::Describe(args) => describe_cmd(args).await,
@@ -170,7 +170,7 @@ impl OperatorArgs {
 }
 
 #[instrument]
-async fn list_cmd(args: &OperatorListArgs, common_args: &Cli) -> Result<String, OperatorCmdError> {
+async fn list_cmd(args: &OperatorListArgs, common_args: &Cli) -> Result<String, CmdError> {
     debug!("Listing operators");
 
     // Build map which maps Helm repo name to Helm repo URL
@@ -213,7 +213,7 @@ async fn list_cmd(args: &OperatorListArgs, common_args: &Cli) -> Result<String, 
 }
 
 #[instrument]
-async fn describe_cmd(args: &OperatorDescribeArgs) -> Result<String, OperatorCmdError> {
+async fn describe_cmd(args: &OperatorDescribeArgs) -> Result<String, CmdError> {
     debug!("Describing operator {}", args.operator_name);
 
     // Build map which maps Helm repo name to Helm repo URL
@@ -257,10 +257,7 @@ async fn describe_cmd(args: &OperatorDescribeArgs) -> Result<String, OperatorCmd
 }
 
 #[instrument]
-async fn install_cmd(
-    args: &OperatorInstallArgs,
-    common_args: &Cli,
-) -> Result<String, OperatorCmdError> {
+async fn install_cmd(args: &OperatorInstallArgs, common_args: &Cli) -> Result<String, CmdError> {
     info!("Installing operator(s)");
 
     println!(
@@ -290,7 +287,7 @@ async fn install_cmd(
         match operator.install(&args.operator_namespace) {
             Ok(_) => println!("Installed {} operator", operator.name),
             Err(err) => {
-                return Err(OperatorCmdError::HelmError { source: err });
+                return Err(CmdError::HelmError { source: err });
             }
         };
     }
@@ -307,10 +304,7 @@ async fn install_cmd(
 }
 
 #[instrument]
-fn uninstall_cmd(
-    args: &OperatorUninstallArgs,
-    common_args: &Cli,
-) -> Result<String, OperatorCmdError> {
+fn uninstall_cmd(args: &OperatorUninstallArgs, common_args: &Cli) -> Result<String, CmdError> {
     info!("Uninstalling operator(s)");
 
     for operator in &args.operators {
@@ -331,10 +325,7 @@ fn uninstall_cmd(
 }
 
 #[instrument]
-fn installed_cmd(
-    args: &OperatorInstalledArgs,
-    common_args: &Cli,
-) -> Result<String, OperatorCmdError> {
+fn installed_cmd(args: &OperatorInstalledArgs, common_args: &Cli) -> Result<String, CmdError> {
     debug!("Listing installed operators");
 
     type ReleaseList = IndexMap<String, HelmRelease>;
@@ -388,7 +379,7 @@ fn installed_cmd(
 
 /// Builds a map which maps Helm repo name to Helm repo URL.
 #[instrument]
-async fn build_helm_index_file_list<'a>() -> Result<HashMap<&'a str, HelmRepo>, OperatorCmdError> {
+async fn build_helm_index_file_list<'a>() -> Result<HashMap<&'a str, HelmRepo>, CmdError> {
     debug!("Building Helm index file list");
 
     let mut helm_index_files = HashMap::new();
@@ -417,7 +408,7 @@ async fn build_helm_index_file_list<'a>() -> Result<HashMap<&'a str, HelmRepo>, 
 #[instrument]
 fn build_versions_list(
     helm_index_files: &HashMap<&str, HelmRepo>,
-) -> Result<IndexMap<String, OperatorVersionList>, OperatorCmdError> {
+) -> Result<IndexMap<String, OperatorVersionList>, CmdError> {
     debug!("Building versions list");
 
     let mut versions_list = IndexMap::new();
@@ -440,7 +431,7 @@ fn build_versions_list(
 fn build_versions_list_for_operator<T>(
     operator_name: T,
     helm_index_files: &HashMap<&str, HelmRepo>,
-) -> Result<OperatorVersionList, OperatorCmdError>
+) -> Result<OperatorVersionList, CmdError>
 where
     T: AsRef<str> + std::fmt::Debug,
 {
@@ -465,7 +456,7 @@ where
 fn list_operator_versions_from_repo<T>(
     operator_name: T,
     helm_repo: &HelmRepo,
-) -> Result<Vec<String>, OperatorCmdError>
+) -> Result<Vec<String>, CmdError>
 where
     T: AsRef<str> + std::fmt::Debug,
 {

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -93,7 +93,7 @@ pub struct ReleaseUninstallArgs {
 }
 
 #[derive(Debug, Snafu)]
-pub enum ReleaseCmdError {
+pub enum CmdError {
     #[snafu(display("unable to format yaml output"))]
     YamlOutputFormatError { source: serde_yaml::Error },
 
@@ -120,7 +120,7 @@ pub enum ReleaseCmdError {
 }
 
 impl ReleaseArgs {
-    pub async fn run(&self, common_args: &Cli, cache: Cache) -> Result<String, ReleaseCmdError> {
+    pub async fn run(&self, common_args: &Cli, cache: Cache) -> Result<String, CmdError> {
         debug!("Handle release args");
 
         let transfer_client = FileTransferClient::new_with(cache);
@@ -147,10 +147,7 @@ impl ReleaseArgs {
 }
 
 #[instrument]
-async fn list_cmd(
-    args: &ReleaseListArgs,
-    release_list: ReleaseList,
-) -> Result<String, ReleaseCmdError> {
+async fn list_cmd(args: &ReleaseListArgs, release_list: ReleaseList) -> Result<String, CmdError> {
     info!("Listing releases");
 
     match args.output_type {
@@ -186,7 +183,7 @@ async fn list_cmd(
 async fn describe_cmd(
     args: &ReleaseDescribeArgs,
     release_list: ReleaseList,
-) -> Result<String, ReleaseCmdError> {
+) -> Result<String, CmdError> {
     info!("Describing release");
 
     let release = release_list.get(&args.release);
@@ -232,7 +229,7 @@ async fn install_cmd(
     args: &ReleaseInstallArgs,
     common_args: &Cli,
     release_list: ReleaseList,
-) -> Result<String, ReleaseCmdError> {
+) -> Result<String, CmdError> {
     info!("Installing release");
 
     // Install local cluster if needed
@@ -260,7 +257,7 @@ async fn install_cmd(
 async fn uninstall_cmd(
     args: &ReleaseUninstallArgs,
     release_list: ReleaseList,
-) -> Result<String, ReleaseCmdError> {
+) -> Result<String, CmdError> {
     info!("Installing release");
 
     match release_list.get(&args.release) {

--- a/rust/stackablectl/src/cmds/stack.rs
+++ b/rust/stackablectl/src/cmds/stack.rs
@@ -103,7 +103,7 @@ Use \"stackablectl stack describe <STACK>\" to list available parameters for eac
 }
 
 #[derive(Debug, Snafu)]
-pub enum StackCmdError {
+pub enum CmdError {
     #[snafu(display("path/url parse error"))]
     PathOrUrlParseError { source: PathOrUrlParseError },
 
@@ -133,7 +133,7 @@ pub enum StackCmdError {
 }
 
 impl StackArgs {
-    pub async fn run(&self, common_args: &Cli, cache: Cache) -> Result<String, StackCmdError> {
+    pub async fn run(&self, common_args: &Cli, cache: Cache) -> Result<String, CmdError> {
         debug!("Handle stack args");
 
         let transfer_client = FileTransferClient::new_with(cache);
@@ -154,7 +154,7 @@ impl StackArgs {
 }
 
 #[instrument]
-fn list_cmd(args: &StackListArgs, stack_list: StackList) -> Result<String, StackCmdError> {
+fn list_cmd(args: &StackListArgs, stack_list: StackList) -> Result<String, CmdError> {
     info!("Listing stacks");
 
     match args.output_type {
@@ -183,7 +183,7 @@ fn list_cmd(args: &StackListArgs, stack_list: StackList) -> Result<String, Stack
 }
 
 #[instrument]
-fn describe_cmd(args: &StackDescribeArgs, stack_list: StackList) -> Result<String, StackCmdError> {
+fn describe_cmd(args: &StackDescribeArgs, stack_list: StackList) -> Result<String, CmdError> {
     info!("Describing stack {}", args.stack_name);
 
     match stack_list.get(&args.stack_name) {
@@ -231,7 +231,7 @@ async fn install_cmd(
     common_args: &Cli,
     stack_list: StackList,
     transfer_client: &FileTransferClient,
-) -> Result<String, StackCmdError> {
+) -> Result<String, CmdError> {
     info!("Installing stack {}", args.stack_name);
 
     let files = common_args

--- a/rust/stackablectl/src/cmds/stacklets.rs
+++ b/rust/stackablectl/src/cmds/stacklets.rs
@@ -43,7 +43,7 @@ pub struct StackletListArgs {
 }
 
 #[derive(Debug, Snafu)]
-pub enum StackletsCmdError {
+pub enum CmdError {
     #[snafu(display("service list error"))]
     StackletListError { source: StackletError },
 
@@ -55,7 +55,7 @@ pub enum StackletsCmdError {
 }
 
 impl StackletsArgs {
-    pub async fn run(&self, common_args: &Cli) -> Result<String, StackletsCmdError> {
+    pub async fn run(&self, common_args: &Cli) -> Result<String, CmdError> {
         match &self.subcommand {
             StackletCommands::List(args) => list_cmd(args, common_args).await,
         }
@@ -63,7 +63,7 @@ impl StackletsArgs {
 }
 
 #[instrument]
-async fn list_cmd(args: &StackletListArgs, common_args: &Cli) -> Result<String, StackletsCmdError> {
+async fn list_cmd(args: &StackletListArgs, common_args: &Cli) -> Result<String, CmdError> {
     info!("Listing installed stacklets");
 
     // If the user wants to list stacklets from all namespaces, we use `None`.

--- a/rust/stackablectl/src/main.rs
+++ b/rust/stackablectl/src/main.rs
@@ -1,50 +1,18 @@
 use clap::Parser;
 use dotenvy::dotenv;
-use snafu::{ResultExt, Snafu};
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::fmt;
 
-use stackablectl::{
-    cli::{self, Commands},
-    cmds::{
-        cache::CacheCmdError, completions::CompletionsCmdError, demo::DemoCmdError,
-        operator::OperatorCmdError, release::ReleaseCmdError, stack::StackCmdError,
-        stacklets::StackletsCmdError,
-    },
-};
-
-#[derive(Debug, Snafu)]
-enum CliError {
-    #[snafu(display("operator command error"))]
-    Operator { source: OperatorCmdError },
-
-    #[snafu(display("release command error"))]
-    Release { source: ReleaseCmdError },
-
-    #[snafu(display("stack command error"))]
-    Stack { source: StackCmdError },
-
-    #[snafu(display("stacklets command error"))]
-    Stacklets { source: StackletsCmdError },
-
-    #[snafu(display("demo command error"))]
-    Demo { source: DemoCmdError },
-
-    #[snafu(display("completions command error"))]
-    Completions { source: CompletionsCmdError },
-
-    #[snafu(display("cache command error"))]
-    Cache { source: CacheCmdError },
-}
+use stackablectl::cli::{Cli, Error};
 
 #[snafu::report]
 #[tokio::main]
-async fn main() -> Result<(), CliError> {
+async fn main() -> Result<(), Error> {
     // Parse the CLI args and commands
-    let cli = cli::Cli::parse();
+    let app = Cli::parse();
 
     // Catch if --offline is used for now
-    if cli.offline {
+    if app.offline {
         todo!()
     }
 
@@ -55,7 +23,7 @@ async fn main() -> Result<(), CliError> {
         .with_target(false);
 
     tracing_subscriber::fmt()
-        .with_max_level(match cli.log_level {
+        .with_max_level(match app.log_level {
             Some(level) => LevelFilter::from_level(level),
             None => LevelFilter::WARN,
         })
@@ -73,31 +41,7 @@ async fn main() -> Result<(), CliError> {
         }
     }
 
-    // Add Helm repos
-    if let Err(err) = cli.add_helm_repos() {
-        eprintln!("{err}")
-    };
-
-    let cache = cli
-        .cache_settings()
-        .unwrap()
-        .try_into_cache()
-        .await
-        .unwrap();
-
-    // TODO (Techassi): Do we still want to auto purge when running cache commands?
-    cache.auto_purge().await.unwrap();
-
-    let output = match &cli.subcommand {
-        Commands::Operator(args) => args.run(&cli).await.context(OperatorSnafu)?,
-        Commands::Release(args) => args.run(&cli, cache).await.context(ReleaseSnafu)?,
-        Commands::Stack(args) => args.run(&cli, cache).await.context(StackSnafu)?,
-        Commands::Stacklets(args) => args.run(&cli).await.context(StackletsSnafu)?,
-        Commands::Demo(args) => args.run(&cli, cache).await.context(DemoSnafu)?,
-        Commands::Completions(args) => args.run().context(CompletionsSnafu)?,
-        Commands::Cache(args) => args.run(cache).await.context(CacheSnafu)?,
-    };
-
+    let output = app.run().await?;
     println!("{output}");
     Ok(())
 }


### PR DESCRIPTION
Fixes #112 

The `completions` subcommand required access to the internet in order to work. This is not needed at all. The shell completions can be generated without any internet access. Additionally, the `cache` subcommand also doesn't require internet access from now on. Currently, it can only inspect and delete cached files.

Issue #112 is fixed by **not** adding the Helm repos if not required. This PR additionally slightly restructures the CLI code.
