### PR TITLE
Fix duplicate `content-type` headers being sent for assets

### DIFF
--- a/rust/stackable-cockpitd/src/handlers/ui.rs
+++ b/rust/stackable-cockpitd/src/handlers/ui.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::Path,
     http::{header::CONTENT_TYPE, HeaderValue},
-    response::{AppendHeaders, Html, IntoResponse},
+    response::{Html, IntoResponse},
     routing::get,
     Router,
 };
@@ -18,14 +18,14 @@ async fn ui() -> Html<&'static str> {
 }
 async fn asset(Path(name): Path<String>) -> impl IntoResponse {
     (
-        AppendHeaders([(
+        [(
             CONTENT_TYPE,
-            match name.split_once('.') {
+            match name.rsplit_once('.') {
                 Some((_, "js")) => HeaderValue::from_static("text/javascript"),
                 Some((_, "css")) => HeaderValue::from_static("text/css"),
                 _ => HeaderValue::from_static("application/octet-stream"),
             },
-        )]),
+        )],
         stackable_cockpit_web::ASSETS[&name],
     )
 }


### PR DESCRIPTION
# Description

Obsoletes #136, see https://github.com/stackabletech/stackable-cockpit/pull/136#discussion_r1381278672

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
