### PR TITLE
chore: Release stackablectl-1.0.0-rc3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 dependencies = [
  "clap",
  "clap_complete",

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 1.0.0-rc2" 
+.TH stackablectl 1  "stackablectl 1.0.0-rc3" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -95,6 +95,6 @@ Interact with locally cached files
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v1.0.0\-rc2
+v1.0.0\-rc3
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "1.0.0-rc2"
+version = "1.0.0-rc3"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR bumps the `stackablectl` to version `1.0.0-rc3`. It includes the FFI/cgo fix. See #131 and #133 for more details.