### PR TITLE
docs: Add listener-operator where missing

### DIFF
--- a/.github/workflows/pr_general.yml
+++ b/.github/workflows/pr_general.yml
@@ -37,10 +37,11 @@ jobs:
           cache: yarn
       - run: yarn install --frozen-lockfile
 
-      - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+      - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
         with:
           key: udeps
-      - run: cargo install cargo-udeps
+          cache-all-crates: "true"
+      - run: cargo install --locked cargo-udeps@0.1.39
       - run: cargo udeps --workspace
 
   run_cargodeny:

--- a/docs/modules/stackablectl/pages/commands/demo.adoc
+++ b/docs/modules/stackablectl/pages/commands/demo.adoc
@@ -79,13 +79,8 @@ You can now use your cluster with:
 
 kubectl cluster-info --context kind-stackable-data-platform
 
-Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
-The release commons-operator was successfully installed.
-The release hive-operator was successfully installed.
-The release opa-operator was successfully installed.
-The release secret-operator was successfully installed.
-The release superset-operator was successfully installed.
-The release trino-operator was successfully installed.
+Have a nice day! 👋
+
 Installed demo trino-taxi-data
 
 Use "stackablectl operator installed" to display the installed operators
@@ -124,12 +119,6 @@ $ stackablectl demo install trino-taxi-data -c minikube
     ▪ env NO_PROXY=192.168.58.2
 🔎  Verifying Kubernetes components...
 🏄  Done! kubectl is now configured to use "stackable-data-platform" cluster and "default" namespace by default
-The release commons-operator was successfully installed.
-The release hive-operator was successfully installed.
-The release opa-operator was successfully installed.
-The release secret-operator was successfully installed.
-The release superset-operator was successfully installed.
-The release trino-operator was successfully installed.
 Installed demo trino-taxi-data
 
 Use "stackablectl operator installed" to display the installed operators

--- a/docs/modules/stackablectl/pages/commands/operator.adoc
+++ b/docs/modules/stackablectl/pages/commands/operator.adoc
@@ -53,12 +53,13 @@ will install the operators in their latest nightly version - built from the main
 
 [source,console]
 ----
-$ stackablectl operator install airflow commons secret
-Installing 3 operators
+$ stackablectl operator install airflow commons secret listener
+Installing 4 operators
 Installed airflow operator
 Installed commons operator
 Installed secret operator
-Installed 3 operators
+Installed listener operator
+Installed 4 operators
 ----
 
 If you don't have a Kubernetes cluster available, `stackablectl` can spin up a https://kind.sigs.k8s.io/[kind] or
@@ -66,22 +67,23 @@ https://minikube.sigs.k8s.io/docs/[minikube] Kubernetes cluster for you. Based o
 use, ensure you have either `kind` or `minikube` installed on your system. See
 xref:commands/demo.adoc#_using_a_local_kubernetes_cluster[here] for more information.
 
-With this command, we installed the operator for Apache Airflow and two operators needed internally by the Stackable
-Data Platform (commons and secret). As we didn't specify a specific version to install, the operators were installed in
+With this command, we installed the operator for Apache Airflow and three operators needed internally by the Stackable
+Data Platform (commons, secret and listener). As we didn't specify a specific version to install, the operators were installed in
 the latest nightly version - built from the main branch of the operators. If you want to install a specific version, you
 can add the version to each operator to install as follows:
 
 [source,console]
 ----
-$ stackablectl operator install airflow=23.7 commons=23.7 secret=23.7
-Installing 3 operators
+$ stackablectl operator install airflow=23.7 commons=23.7 secret=23.7 listener=23.7
+Installing 4 operators
 Installed airflow=23.7 operator
 Installed commons=23.7 operator
 Installed secret=23.7 operator
-Installed 3 operators
+Installed listener=23.7 operator
+Installed 4 operators
 ----
 
-As you can see, the three operators were installed in the requested version.
+As you can see, the four operators were installed in the requested version.
 
 Remember: If you want to install a recommended and tested set of operator versions, look at the
 xref:commands/release.adoc[`stackablectl release`] command.
@@ -93,15 +95,17 @@ After installing some operators, you can list which operators are installed in y
 [source,console]
 ----
 $ stackablectl operator installed
-┌──────────────────┬─────────┬─────────────────────┬──────────┬──────────────────────────────────────────┐
-│ OPERATOR         ┆ VERSION ┆ NAMESPACE           ┆ STATUS   ┆ LAST UPDATED                             │
-╞══════════════════╪═════════╪═════════════════════╪══════════╪══════════════════════════════════════════╡
-│ airflow-operator ┆ 23.7.0  ┆ stackable-operators ┆ deployed ┆ 2023-08-23 17:33:01.509777626 +0200 CEST │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ commons-operator ┆ 23.7.0  ┆ stackable-operators ┆ deployed ┆ 2023-08-23 17:33:04.012698515 +0200 CEST │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ secret-operator  ┆ 23.7.0  ┆ stackable-operators ┆ deployed ┆ 2023-08-23 17:33:06.328410802 +0200 CEST │
-└──────────────────┴─────────┴─────────────────────┴──────────┴──────────────────────────────────────────┘
+┌────────────────────┬─────────┬─────────────────────┬──────────┬──────────────────────────────────────────┐
+│ OPERATOR           ┆ VERSION ┆ NAMESPACE           ┆ STATUS   ┆ LAST UPDATED                             │
+╞════════════════════╪═════════╪═════════════════════╪══════════╪══════════════════════════════════════════╡
+│ airflow-operator   ┆ 23.7.0  ┆ stackable-operators ┆ deployed ┆ 2023-08-23 17:33:01.509777626 +0200 CEST │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ commons-operator   ┆ 23.7.0  ┆ stackable-operators ┆ deployed ┆ 2023-08-23 17:33:04.012698515 +0200 CEST │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ listener-operator  ┆ 23.7.0  ┆ stackable-operators ┆ deployed ┆ 2023-08-23 17:33:07.217309791 +0200 CEST │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ secret-operator    ┆ 23.7.0  ┆ stackable-operators ┆ deployed ┆ 2023-08-23 17:33:06.328410802 +0200 CEST │
+└────────────────────┴─────────┴─────────────────────┴──────────┴──────────────────────────────────────────┘
 ----
 
 == Uninstalling Operators
@@ -110,9 +114,10 @@ You can use the `stackablectl operator uninstall` command to uninstall the opera
 
 [source,console]
 ----
-$ stackablectl operator uninstall airflow commons secret
+$ stackablectl operator uninstall airflow commons secret listener
 The release airflow-operator was successfully uninstalled.
 The release commons-operator was successfully uninstalled.
 The release secret-operator was successfully uninstalled.
-Uninstalled 3 operators
+The release listener-operator was successfully uninstalled.
+Uninstalled 4 operators
 ----

--- a/docs/modules/stackablectl/pages/quickstart.adoc
+++ b/docs/modules/stackablectl/pages/quickstart.adoc
@@ -48,12 +48,6 @@ Kubernetes client is configured to interact with the Kubernetes cluster. After t
 [source,console]
 ----
 $ stackablectl demo install trino-taxi-data
-The release commons-operator was successfully installed.
-The release hive-operator was successfully installed.
-The release opa-operator was successfully installed.
-The release secret-operator was successfully installed.
-The release superset-operator was successfully installed.
-The release trino-operator was successfully installed.
 Installed demo trino-taxi-data
 
 Use "stackablectl operator installed" to display the installed operators
@@ -81,13 +75,8 @@ You can now use your cluster with:
 
 kubectl cluster-info --context kind-stackable-data-platform
 
-Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
-The release commons-operator was successfully installed.
-The release hive-operator was successfully installed.
-The release opa-operator was successfully installed.
-The release secret-operator was successfully installed.
-The release superset-operator was successfully installed.
-The release trino-operator was successfully installed.
+Have a nice day! 👋
+
 Installed demo trino-taxi-data
 
 Use "stackablectl operator installed" to display the installed operators


### PR DESCRIPTION
# Description

The listener-operator is now one of the fundamental operators, along with the commons- and secret-operators, and should be mentioned accordingly everywhere.

stackablectl 1.0.0-rc3 does not output anymore the installed operators, so I removed them:

```
The release commons-operator was successfully installed.
The release hive-operator was successfully installed.
The release opa-operator was successfully installed.
The release secret-operator was successfully installed.
The release superset-operator was successfully installed.
The release trino-operator was successfully installed.
```

Apply the settings from operator-templating to `rust-cache` and `cargo udeps` (https://github.com/stackabletech/operator-templating/blob/bacdd9bf7c66f0246092a8db89082d3d1dbc0703/template/.github/workflows/build.yml.j2#L47-L52). `cargo udeps` is now pinned to a version which works with the given Rust version.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [x] Documentation added or updated
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
