### PR TITLE
feat: allow plain output support

### DIFF
--- a/rust/stackablectl/src/cli/mod.rs
+++ b/rust/stackablectl/src/cli/mod.rs
@@ -244,9 +244,9 @@ CRDs."
 
 #[derive(Clone, Debug, Default, ValueEnum)]
 pub enum OutputType {
-    /// Print output formatted as plain text
+    /// Print output formatted as a table
     #[default]
-    Plain,
+    Table,
 
     /// Print output formatted as JSON
     Json,

--- a/rust/stackablectl/src/cli/mod.rs
+++ b/rust/stackablectl/src/cli/mod.rs
@@ -244,6 +244,9 @@ CRDs."
 
 #[derive(Clone, Debug, Default, ValueEnum)]
 pub enum OutputType {
+    /// Print output formatted as plain text
+    Plain,
+
     /// Print output formatted as a table
     #[default]
     Table,

--- a/rust/stackablectl/src/cmds/demo.rs
+++ b/rust/stackablectl/src/cmds/demo.rs
@@ -167,13 +167,17 @@ async fn list_cmd(args: &DemoListArgs, cli: &Cli, list: demo::List) -> Result<St
     info!("Listing demos");
 
     match args.output_type {
-        OutputType::Table => {
-            let mut table = Table::new();
+        OutputType::Plain | OutputType::Table => {
+            let (arrangement, preset) = match args.output_type {
+                OutputType::Plain => (ContentArrangement::Disabled, NOTHING),
+                _ => (ContentArrangement::Dynamic, UTF8_FULL),
+            };
 
+            let mut table = Table::new();
             table
-                .set_content_arrangement(ContentArrangement::Dynamic)
                 .set_header(vec!["#", "NAME", "STACK", "DESCRIPTION"])
-                .load_preset(UTF8_FULL);
+                .set_content_arrangement(arrangement)
+                .load_preset(preset);
 
             for (index, (demo_name, demo_spec)) in list.inner().iter().enumerate() {
                 let row = Row::from(vec![
@@ -219,6 +223,7 @@ async fn describe_cmd(
     })?;
 
     match args.output_type {
+        OutputType::Plain => todo!(),
         OutputType::Table => {
             let mut table = Table::new();
             table

--- a/rust/stackablectl/src/cmds/demo.rs
+++ b/rust/stackablectl/src/cmds/demo.rs
@@ -223,12 +223,16 @@ async fn describe_cmd(
     })?;
 
     match args.output_type {
-        OutputType::Plain => todo!(),
-        OutputType::Table => {
+        OutputType::Plain | OutputType::Table => {
+            let arrangement = match args.output_type {
+                OutputType::Plain => ContentArrangement::Disabled,
+                _ => ContentArrangement::Dynamic,
+            };
+
             let mut table = Table::new();
             table
+                .set_content_arrangement(arrangement)
                 .load_preset(NOTHING)
-                .set_content_arrangement(ContentArrangement::Dynamic)
                 .add_row(vec!["DEMO", &args.demo_name])
                 .add_row(vec!["DESCRIPTION", &demo.description])
                 .add_row_if(

--- a/rust/stackablectl/src/cmds/demo.rs
+++ b/rust/stackablectl/src/cmds/demo.rs
@@ -167,7 +167,7 @@ async fn list_cmd(args: &DemoListArgs, cli: &Cli, list: demo::List) -> Result<St
     info!("Listing demos");
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             let mut table = Table::new();
 
             table
@@ -219,7 +219,7 @@ async fn describe_cmd(
     })?;
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             let mut table = Table::new();
             table
                 .load_preset(NOTHING)

--- a/rust/stackablectl/src/cmds/operator.rs
+++ b/rust/stackablectl/src/cmds/operator.rs
@@ -230,8 +230,12 @@ async fn describe_cmd(args: &OperatorDescribeArgs, cli: &Cli) -> Result<String, 
     let versions_list = build_versions_list_for_operator(&args.operator_name, &helm_index_files)?;
 
     match args.output_type {
-        OutputType::Plain => todo!(),
-        OutputType::Table => {
+        OutputType::Plain | OutputType::Table => {
+            let arrangement = match args.output_type {
+                OutputType::Plain => ContentArrangement::Disabled,
+                _ => ContentArrangement::Dynamic,
+            };
+
             let stable_versions_string = match versions_list.0.get(HELM_REPO_NAME_STABLE) {
                 Some(v) => v.join(", "),
                 None => "".into(),
@@ -249,7 +253,7 @@ async fn describe_cmd(args: &OperatorDescribeArgs, cli: &Cli) -> Result<String, 
 
             let mut table = Table::new();
             table
-                .set_content_arrangement(ContentArrangement::Dynamic)
+                .set_content_arrangement(arrangement)
                 .load_preset(NOTHING)
                 .add_row(vec!["OPERATOR", &args.operator_name.to_string()])
                 .add_row(vec!["STABLE VERSIONS", stable_versions_string.as_str()])

--- a/rust/stackablectl/src/cmds/operator.rs
+++ b/rust/stackablectl/src/cmds/operator.rs
@@ -175,7 +175,7 @@ async fn list_cmd(args: &OperatorListArgs, cli: &Cli) -> Result<String, CmdError
     let versions_list = build_versions_list(&helm_index_files)?;
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             let mut table = Table::new();
 
             table
@@ -226,7 +226,7 @@ async fn describe_cmd(args: &OperatorDescribeArgs, cli: &Cli) -> Result<String, 
     let versions_list = build_versions_list_for_operator(&args.operator_name, &helm_index_files)?;
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             let stable_versions_string = match versions_list.0.get(HELM_REPO_NAME_STABLE) {
                 Some(v) => v.join(", "),
                 None => "".into(),
@@ -359,7 +359,7 @@ fn installed_cmd(args: &OperatorInstalledArgs, cli: &Cli) -> Result<String, CmdE
         .collect();
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             if installed.is_empty() {
                 return Ok("No installed operators".into());
             }

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -154,17 +154,21 @@ async fn list_cmd(
     info!("Listing releases");
 
     match args.output_type {
-        OutputType::Table => {
+        OutputType::Plain | OutputType::Table => {
             if release_list.inner().is_empty() {
                 return Ok("No releases".into());
             }
 
-            let mut table = Table::new();
+            let (arrangement, preset) = match args.output_type {
+                OutputType::Plain => (ContentArrangement::Disabled, NOTHING),
+                _ => (ContentArrangement::Dynamic, UTF8_FULL),
+            };
 
+            let mut table = Table::new();
             table
-                .set_content_arrangement(ContentArrangement::Dynamic)
-                .load_preset(UTF8_FULL)
-                .set_header(vec!["#", "RELEASE", "RELEASE DATE", "DESCRIPTION"]);
+                .set_header(vec!["#", "RELEASE", "RELEASE DATE", "DESCRIPTION"])
+                .set_content_arrangement(arrangement)
+                .load_preset(preset);
 
             for (index, (release_name, release_spec)) in release_list.inner().iter().enumerate() {
                 table.add_row(vec![
@@ -207,6 +211,7 @@ async fn describe_cmd(
 
     match release {
         Some(release) => match args.output_type {
+            OutputType::Plain => todo!(),
             OutputType::Table => {
                 let mut product_table = Table::new();
 

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -211,14 +211,18 @@ async fn describe_cmd(
 
     match release {
         Some(release) => match args.output_type {
-            OutputType::Plain => todo!(),
-            OutputType::Table => {
+            OutputType::Plain | OutputType::Table => {
+                let arrangement = match args.output_type {
+                    OutputType::Plain => ContentArrangement::Disabled,
+                    _ => ContentArrangement::Dynamic,
+                };
+
                 let mut product_table = Table::new();
 
                 product_table
+                    .set_header(vec!["PRODUCT", "OPERATOR VERSION"])
                     .set_content_arrangement(ContentArrangement::Dynamic)
-                    .load_preset(NOTHING)
-                    .set_header(vec!["PRODUCT", "OPERATOR VERSION"]);
+                    .load_preset(NOTHING);
 
                 for (product_name, product) in &release.products {
                     product_table.add_row(vec![product_name, &product.version.to_string()]);
@@ -227,7 +231,7 @@ async fn describe_cmd(
                 let mut table = Table::new();
 
                 table
-                    .set_content_arrangement(ContentArrangement::Dynamic)
+                    .set_content_arrangement(arrangement)
                     .load_preset(NOTHING)
                     .add_row(vec!["RELEASE", &args.release])
                     .add_row(vec!["RELEASE DATE", release.date.as_str()])

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -154,7 +154,7 @@ async fn list_cmd(
     info!("Listing releases");
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             if release_list.inner().is_empty() {
                 return Ok("No releases".into());
             }
@@ -207,7 +207,7 @@ async fn describe_cmd(
 
     match release {
         Some(release) => match args.output_type {
-            OutputType::Plain => {
+            OutputType::Table => {
                 let mut product_table = Table::new();
 
                 product_table

--- a/rust/stackablectl/src/cmds/stack.rs
+++ b/rust/stackablectl/src/cmds/stack.rs
@@ -150,13 +150,17 @@ fn list_cmd(args: &StackListArgs, cli: &Cli, stack_list: stack::List) -> Result<
     info!("Listing stacks");
 
     match args.output_type {
-        OutputType::Table => {
-            let mut table = Table::new();
+        OutputType::Plain | OutputType::Table => {
+            let (arrangement, preset) = match args.output_type {
+                OutputType::Plain => (ContentArrangement::Disabled, NOTHING),
+                _ => (ContentArrangement::Dynamic, UTF8_FULL),
+            };
 
+            let mut table = Table::new();
             table
-                .set_content_arrangement(ContentArrangement::Dynamic)
                 .set_header(vec!["#", "STACK", "RELEASE", "DESCRIPTION"])
-                .load_preset(UTF8_FULL);
+                .set_content_arrangement(arrangement)
+                .load_preset(preset);
 
             for (index, (stack_name, stack)) in stack_list.inner().iter().enumerate() {
                 table.add_row(vec![
@@ -197,6 +201,7 @@ fn describe_cmd(
 
     match stack_list.get(&args.stack_name) {
         Some(stack) => match args.output_type {
+            OutputType::Plain => todo!(),
             OutputType::Table => {
                 let mut table = Table::new();
 

--- a/rust/stackablectl/src/cmds/stack.rs
+++ b/rust/stackablectl/src/cmds/stack.rs
@@ -150,7 +150,7 @@ fn list_cmd(args: &StackListArgs, cli: &Cli, stack_list: stack::List) -> Result<
     info!("Listing stacks");
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             let mut table = Table::new();
 
             table
@@ -197,7 +197,7 @@ fn describe_cmd(
 
     match stack_list.get(&args.stack_name) {
         Some(stack) => match args.output_type {
-            OutputType::Plain => {
+            OutputType::Table => {
                 let mut table = Table::new();
 
                 let mut parameter_table = Table::new();

--- a/rust/stackablectl/src/cmds/stack.rs
+++ b/rust/stackablectl/src/cmds/stack.rs
@@ -201,15 +201,19 @@ fn describe_cmd(
 
     match stack_list.get(&args.stack_name) {
         Some(stack) => match args.output_type {
-            OutputType::Plain => todo!(),
-            OutputType::Table => {
+            OutputType::Plain | OutputType::Table => {
+                let arrangement = match args.output_type {
+                    OutputType::Plain => ContentArrangement::Disabled,
+                    _ => ContentArrangement::Dynamic,
+                };
+
                 let mut table = Table::new();
 
                 let mut parameter_table = Table::new();
 
                 parameter_table
                     .set_header(vec!["NAME", "DESCRIPTION", "DEFAULT VALUE"])
-                    .set_content_arrangement(ContentArrangement::Dynamic)
+                    .set_content_arrangement(arrangement.clone())
                     .load_preset(NOTHING);
 
                 for parameter in &stack.parameters {
@@ -221,7 +225,7 @@ fn describe_cmd(
                 }
 
                 table
-                    .set_content_arrangement(ContentArrangement::Dynamic)
+                    .set_content_arrangement(arrangement)
                     .load_preset(NOTHING)
                     .add_row(vec!["STACK", args.stack_name.as_str()])
                     .add_row(vec!["DESCRIPTION", stack.description.as_str()])

--- a/rust/stackablectl/src/cmds/stacklet.rs
+++ b/rust/stackablectl/src/cmds/stacklet.rs
@@ -116,7 +116,7 @@ async fn list_cmd(args: &StackletListArgs, cli: &Cli) -> Result<String, CmdError
     }
 
     match args.output_type {
-        OutputType::Plain => {
+        OutputType::Table => {
             // The main table displays all installed (and discovered) stacklets
             // and their condition.
             let mut table = Table::new();


### PR DESCRIPTION
# Description

Resolves #142 

- Rename old `plain` output option to `table`
- Ceate a new output option for `plain` which removes border characters and disables dynamic table arrangement.
  - There is an issue where there are multiple newlines between rows
  - There should be further discussion about what plain output should look like. This PR felt like a good-enough compromise between existing code and avoiding broken hyperlinks
  - We might need to use `force_no_tty()` when the output is plain, but I will look at that in a future PR where I add output options for `cache list`.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
