### PR TITLE
fix: Uninstall operators when removing release

### DIFF
--- a/rust/stackable-cockpit/src/helm.rs
+++ b/rust/stackable-cockpit/src/helm.rs
@@ -186,10 +186,12 @@ pub struct ChartVersion<'a> {
     pub chart_version: Option<&'a str>,
 }
 
-/// Installs a Helm release
+/// Installs a Helm release from a repo.
+///
+/// This function expects the fully qualified Helm release name. In case of our
+/// operators this is: `<PRODUCT_NAME>-operator`.
 #[instrument]
 pub fn install_release_from_repo(
-    operator_name: &str,
     release_name: &str,
     ChartVersion {
         repo_name,
@@ -258,6 +260,10 @@ pub fn install_release_from_repo(
     Ok(InstallReleaseStatus::Installed(release_name.to_string()))
 }
 
+/// Installs a Helm release.
+///
+/// This function expects the fully qualified Helm release name. In case of our
+/// operators this is: `<PRODUCT_NAME>-operator`.
 fn install_release(
     release_name: &str,
     chart_name: &str,
@@ -289,7 +295,10 @@ fn install_release(
     Ok(())
 }
 
-/// Uninstall a Helm release
+/// Uninstall a Helm release.
+///
+/// This function expects the fully qualified Helm release name. In case of our
+/// operators this is: `<PRODUCT_NAME>-operator`.
 #[instrument]
 pub fn uninstall_release(
     release_name: &str,

--- a/rust/stackable-cockpit/src/platform/operator/mod.rs
+++ b/rust/stackable-cockpit/src/platform/operator/mod.rs
@@ -185,7 +185,6 @@ impl OperatorSpec {
 
         // Install using Helm
         helm::install_release_from_repo(
-            &self.name,
             &helm_name,
             helm::ChartVersion {
                 chart_version: version.as_deref(),

--- a/rust/stackable-cockpit/src/platform/release/spec.rs
+++ b/rust/stackable-cockpit/src/platform/release/spec.rs
@@ -8,7 +8,10 @@ use utoipa::ToSchema;
 
 use crate::{
     helm,
-    platform::{operator, product},
+    platform::{
+        operator::{self, OperatorSpec},
+        product,
+    },
 };
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -52,10 +55,10 @@ impl ReleaseSpec {
         info!("Installing release");
 
         for (product_name, product) in self.filter_products(include_products, exclude_products) {
-            info!("Installing product {}", product_name);
+            info!("Installing {}-operator", product_name);
 
             // Create operator spec
-            let operator = operator::OperatorSpec::new(product_name, Some(product.version.clone()))
+            let operator = OperatorSpec::new(product_name, Some(product.version.clone()))
                 .context(OperatorSpecParseSnafu)?;
 
             // Install operator
@@ -65,9 +68,20 @@ impl ReleaseSpec {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     pub fn uninstall(&self, namespace: &str) -> Result<()> {
-        for (product_name, _) in &self.products {
-            helm::uninstall_release(product_name, namespace, true).context(HelmUninstallSnafu)?;
+        info!("Uninstalling release");
+
+        for (product_name, product_spec) in &self.products {
+            info!("Uninstalling {}-operator", product_name);
+
+            // Create operator spec
+            let operator = OperatorSpec::new(product_name, Some(product_spec.version.clone()))
+                .context(OperatorSpecParseSnafu)?;
+
+            // Uninstall operator
+            helm::uninstall_release(&operator.helm_name(), namespace, true)
+                .context(HelmUninstallSnafu)?;
         }
 
         Ok(())

--- a/rust/stackable-cockpit/src/platform/release/spec.rs
+++ b/rust/stackable-cockpit/src/platform/release/spec.rs
@@ -55,7 +55,7 @@ impl ReleaseSpec {
         info!("Installing release");
 
         for (product_name, product) in self.filter_products(include_products, exclude_products) {
-            info!("Installing {}-operator", product_name);
+            info!("Installing {product_name}-operator");
 
             // Create operator spec
             let operator = OperatorSpec::new(product_name, Some(product.version.clone()))
@@ -73,7 +73,7 @@ impl ReleaseSpec {
         info!("Uninstalling release");
 
         for (product_name, product_spec) in &self.products {
-            info!("Uninstalling {}-operator", product_name);
+            info!("Uninstalling {product_name}-operator");
 
             // Create operator spec
             let operator = OperatorSpec::new(product_name, Some(product_spec.version.clone()))

--- a/rust/stackable-cockpit/src/platform/service.rs
+++ b/rust/stackable-cockpit/src/platform/service.rs
@@ -192,7 +192,7 @@ pub async fn get_endpoint_urls_for_loadbalancer(
         .as_ref()
         .and_then(|s| s.load_balancer.as_ref())
         .and_then(|l| l.ingress.as_ref())
-        .and_then(|l| l.get(0));
+        .and_then(|l| l.first());
 
     if let Some(lb_host) = lb_host {
         let lb_host = lb_host.hostname.as_ref().or(lb_host.ip.as_ref());

--- a/rust/stackable-cockpit/src/platform/stack/spec.rs
+++ b/rust/stackable-cockpit/src/platform/stack/spec.rs
@@ -287,7 +287,6 @@ impl StackSpec {
                     // Install the Helm chart using the Helm wrapper
                     helm::install_release_from_repo(
                         &helm_chart.release_name,
-                        &helm_chart.release_name,
                         helm::ChartVersion {
                             repo_name: &helm_chart.repo.name,
                             chart_name: &helm_chart.name,

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,13 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `stackablectl release uninstall` command. It now deletes the operators included in the selected release correctly
+  ([#173]).
+
+[#173]: https://github.com/stackabletech/stackable-cockpit/pull/173
+
 ## [23.11.2] - 2024-01-02
 
 ### Changed
 
-- Bumped Rust version from `1.74.0` to `1.75.0` ([#172]).
-- Bumped Rust and Go dependencies ([#135], [#162], [#167], [#168], [#170]).
-- Renamed old output style `plain` to `table`. The new output option `plain` will output a reduced view (which removes
+- Bump Rust version from `1.74.0` to `1.75.0` ([#172]).
+- Bump Rust and Go dependencies ([#135], [#162], [#167], [#168], [#170]).
+- Rename old output style `plain` to `table`. The new output option `plain` will output a reduced view (which removes
   borders from tables for example) ([#142], [#163]).
 
 [#135]: https://github.com/stackabletech/stackable-cockpit/pull/135
@@ -36,6 +43,6 @@ First official release of the `stackablectl` rewrite.
 
 ### Changed
 
-- Bumped Rust version from `1.73.0` to `1.74.0` ([#151]).
+- Bump Rust version from `1.73.0` to `1.74.0` ([#151]).
 
 [#151]: https://github.com/stackabletech/stackable-cockpit/pull/151

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix `stackablectl release uninstall` command. It now deletes the operators included in the selected release correctly
-  ([#173]).
+  ([#174]).
 
-[#173]: https://github.com/stackabletech/stackable-cockpit/pull/173
+[#174]: https://github.com/stackabletech/stackable-cockpit/pull/174
 
 ## [23.11.2] - 2024-01-02
 

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -145,7 +145,7 @@ impl ReleaseArgs {
     }
 }
 
-#[instrument]
+#[instrument(skip(cli, release_list))]
 async fn list_cmd(
     args: &ReleaseListArgs,
     cli: &Cli,
@@ -199,7 +199,7 @@ async fn list_cmd(
     }
 }
 
-#[instrument]
+#[instrument(skip(cli, release_list))]
 async fn describe_cmd(
     args: &ReleaseDescribeArgs,
     cli: &Cli,
@@ -260,14 +260,12 @@ async fn describe_cmd(
     }
 }
 
-#[instrument]
+#[instrument(skip(cli, release_list))]
 async fn install_cmd(
     args: &ReleaseInstallArgs,
     cli: &Cli,
     release_list: release::List,
 ) -> Result<String, CmdError> {
-    info!("Installing release");
-
     match release_list.get(&args.release) {
         Some(release) => {
             let mut output = cli.result();
@@ -306,13 +304,12 @@ async fn install_cmd(
     }
 }
 
+#[instrument(skip(cli, release_list))]
 async fn uninstall_cmd(
     args: &ReleaseUninstallArgs,
     cli: &Cli,
     release_list: release::List,
 ) -> Result<String, CmdError> {
-    info!("Installing release");
-
     match release_list.get(&args.release) {
         Some(release) => {
             release


### PR DESCRIPTION
Fixes the release uninstall process by deleting installed operators correctly.