### PR TITLE
fix: Use the provided cluster name when creating a local cluster

### DIFF
--- a/rust/stackable-cockpit/src/engine/kind/mod.rs
+++ b/rust/stackable-cockpit/src/engine/kind/mod.rs
@@ -5,7 +5,6 @@ use tokio::{io::AsyncWriteExt, process::Command};
 use tracing::{debug, info, instrument};
 
 use crate::{
-    constants::DEFAULT_LOCAL_CLUSTER_NAME,
     engine::{
         docker::{self, check_if_docker_is_running},
         kind::config::Config,
@@ -56,11 +55,11 @@ impl Cluster {
     /// system, but instead will return a data structure representing the
     /// cluster. To actually create the cluster, the `create` method must be
     /// called.
-    pub fn new(node_count: usize, cp_node_count: usize, name: Option<String>) -> Self {
+    pub fn new(node_count: usize, cp_node_count: usize, name: String) -> Self {
         Self {
-            name: name.unwrap_or(DEFAULT_LOCAL_CLUSTER_NAME.into()),
             cp_node_count,
             node_count,
+            name,
         }
     }
 

--- a/rust/stackable-cockpit/src/engine/minikube/mod.rs
+++ b/rust/stackable-cockpit/src/engine/minikube/mod.rs
@@ -3,7 +3,6 @@ use tokio::process::Command;
 use tracing::{debug, info, instrument};
 
 use crate::{
-    constants::DEFAULT_LOCAL_CLUSTER_NAME,
     engine::docker::{self, check_if_docker_is_running},
     utils::check::binaries_present_with_name,
 };
@@ -37,11 +36,8 @@ pub struct Cluster {
 impl Cluster {
     /// Create a new kind cluster. This will NOT yet create the cluster on the system, but instead will return a data
     /// structure representing the cluster. To actually create the cluster, the `create` method must be called.
-    pub fn new(node_count: usize, name: Option<String>) -> Self {
-        Self {
-            name: name.unwrap_or(DEFAULT_LOCAL_CLUSTER_NAME.into()),
-            node_count,
-        }
+    pub fn new(node_count: usize, name: String) -> Self {
+        Self { node_count, name }
     }
 
     /// Create a new local cluster by calling the Minikube binary

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `--cluster-name` not taking effect. The local test clusters always used the default cluster name ([#181]).
+
+[#181]: https://github.com/stackabletech/stackable-cockpit/pull/181
+
 ## [23.11.3] - 2024-01-03
 
 ### Fixed

--- a/rust/stackablectl/src/args/cluster.rs
+++ b/rust/stackablectl/src/args/cluster.rs
@@ -76,18 +76,18 @@ impl CommonClusterArgs {
     /// skips creation of the local cluster. If a cluster needs to be created,
     /// the function first validates cluster node counts. If this validation
     /// fails, an error is returned.
-    pub async fn install_if_needed(
-        &self,
-        name: Option<String>,
-    ) -> Result<(), CommonClusterArgsError> {
+    pub async fn install_if_needed(&self) -> Result<(), CommonClusterArgsError> {
         match &self.cluster_type {
             Some(cluster_type) => {
                 self.validate()?;
 
                 match cluster_type {
                     ClusterType::Kind => {
-                        let kind_cluster =
-                            kind::Cluster::new(self.cluster_nodes, self.cluster_cp_nodes, name);
+                        let kind_cluster = kind::Cluster::new(
+                            self.cluster_nodes,
+                            self.cluster_cp_nodes,
+                            self.cluster_name.clone(),
+                        );
 
                         kind_cluster
                             .create_if_not_exists()
@@ -95,7 +95,8 @@ impl CommonClusterArgs {
                             .context(KindClusterCreateSnafu)
                     }
                     ClusterType::Minikube => {
-                        let minikube_cluster = minikube::Cluster::new(self.cluster_nodes, name);
+                        let minikube_cluster =
+                            minikube::Cluster::new(self.cluster_nodes, self.cluster_name.clone());
 
                         minikube_cluster
                             .create_if_not_exists()

--- a/rust/stackablectl/src/cmds/demo.rs
+++ b/rust/stackablectl/src/cmds/demo.rs
@@ -292,7 +292,7 @@ async fn install_cmd(
 
     // Install local cluster if needed
     args.local_cluster
-        .install_if_needed(None)
+        .install_if_needed()
         .await
         .context(CommonClusterArgsSnafu)?;
 

--- a/rust/stackablectl/src/cmds/operator.rs
+++ b/rust/stackablectl/src/cmds/operator.rs
@@ -282,7 +282,7 @@ async fn install_cmd(args: &OperatorInstallArgs, cli: &Cli) -> Result<String, Cm
     info!("Installing operator(s)");
 
     args.local_cluster
-        .install_if_needed(None)
+        .install_if_needed()
         .await
         .context(CommonClusterArgsSnafu)?;
 

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -272,7 +272,7 @@ async fn install_cmd(
 
             // Install local cluster if needed
             args.local_cluster
-                .install_if_needed(None)
+                .install_if_needed()
                 .await
                 .context(CommonClusterArgsSnafu)?;
 

--- a/rust/stackablectl/src/cmds/stack.rs
+++ b/rust/stackablectl/src/cmds/stack.rs
@@ -285,7 +285,7 @@ async fn install_cmd(
 
             // Install local cluster if needed
             args.local_cluster
-                .install_if_needed(None)
+                .install_if_needed()
                 .await
                 .context(CommonClusterArgsSnafu)?;
 


### PR DESCRIPTION
Fixes an error reported by @sbernauer on Slack.

The provided `--cluster-name` was not used when creating the local cluster either using `kind` or `minikube`.