### PR TITLE
feat: Add labels to operator Helm values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,8 +2680,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.61.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.61.0#ddc57addbc741e3977b1589e553164505a59f639"
+version = "0.62.0"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=main#5477a2b6facdc2f50cfe308cc067557170ae830c"
 dependencies = [
  "chrono",
  "clap",
@@ -2719,8 +2719,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.61.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.61.0#ddc57addbc741e3977b1589e553164505a59f639"
+version = "0.62.0"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=main#5477a2b6facdc2f50cfe308cc067557170ae830c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2735,6 +2735,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "const_format",
  "directories",
  "dotenvy",
  "indexmap 2.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cc = "1.0.83"
 clap = { version = "4.2.1", features = ["derive", "env"] }
 clap_complete = "4.2"
 comfy-table = { version = "7.0", features = ["custom_styling"] }
+const_format = "0.2.32"
 directories = "5.0"
 dotenvy = "0.15"
 futures = "0.3"
@@ -43,7 +44,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 sha2 = "0.10"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.61.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.62.0" }
 tera = "1.18"
 tokio = { version = "1.29.0", features = ["rt-multi-thread", "macros", "fs", "process"] }
 tower-http = "0.4"
@@ -55,8 +56,8 @@ utoipa-swagger-ui = { version = "3.1", features = ["axum"] }
 uuid = { version = "1.4.0", features = ["v4"] }
 which = "4.4"
 
-# [patch."https://github.com/stackabletech/operator-rs.git"]
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+[patch."https://github.com/stackabletech/operator-rs.git"]
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
 
 [profile.release.package.stackablectl]
 # opt-level = "z" # We don't use that as the binary saving is not *that* big (think of 1MB) and it's not worth it risiking performance for this

--- a/rust/stackable-cockpit/src/constants.rs
+++ b/rust/stackable-cockpit/src/constants.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-pub const REDACTED_PASSWORD: &str = "<redacted>";
+pub const OPERATOR_HELM_VALUE_BASE_URL: &str = "https://raw.githubusercontent.com/stackabletech/";
+pub const OPERATOR_HELM_VALUE_PATH: &str = "main/deploy/helm/";
+
 pub const PASSWORD_LENGTH: usize = 32;
 
 pub const DEFAULT_OPERATOR_NAMESPACE: &str = "stackable-operators";
@@ -14,8 +16,9 @@ pub const DEFAULT_LOCAL_CLUSTER_NAME: &str = "stackable-data-platform";
 
 pub const DEFAULT_AUTO_PURGE_INTERVAL: Duration = Duration::from_secs(60 * 15); // 15 minutes
 pub const DEFAULT_CACHE_MAX_AGE: Duration = Duration::from_secs(60 * 60); // One hour
+
+pub const CACHE_PROTECTED_FILES: &[&str] = &[CACHE_LAST_AUTO_PURGE_FILEPATH];
 pub const CACHE_LAST_AUTO_PURGE_FILEPATH: &str = ".cache-last-purge";
-pub const CACHE_PROTECTED_FILES: &[&str] = &[".cache-last-purge"];
 
 pub const HELM_REPO_NAME_STABLE: &str = "stackable-stable";
 pub const HELM_REPO_NAME_TEST: &str = "stackable-test";

--- a/rust/stackable-cockpit/src/platform/manifests.rs
+++ b/rust/stackable-cockpit/src/platform/manifests.rs
@@ -20,11 +20,8 @@ use crate::{
 #[derive(Debug, Snafu)]
 pub enum Error {
     /// This error indicates that parsing a string into a path or URL failed.
-    #[snafu(display("failed to parse '{path_or_url}' as path/url"))]
-    ParsePathOrUrl {
-        source: PathOrUrlParseError,
-        path_or_url: String,
-    },
+    #[snafu(display("failed to parse path/url"))]
+    ParsePathOrUrl { source: PathOrUrlParseError },
 
     /// This error indicates that receiving remote content failed.
     #[snafu(display("failed to receive remote content"))]
@@ -81,9 +78,7 @@ pub trait InstallManifestsExt {
                     debug!("Installing manifest from Helm chart {}", helm_file);
 
                     // Read Helm chart YAML and apply templating
-                    let helm_file = helm_file.into_path_or_url().context(ParsePathOrUrlSnafu {
-                        path_or_url: helm_file.clone(),
-                    })?;
+                    let helm_file = helm_file.into_path_or_url().context(ParsePathOrUrlSnafu)?;
 
                     let helm_chart: helm::Chart = transfer_client
                         .get(&helm_file, &Template::new(parameters).then(Yaml::new()))
@@ -125,12 +120,9 @@ pub trait InstallManifestsExt {
                     debug!("Installing YAML manifest from {}", manifest_file);
 
                     // Read YAML manifest and apply templating
-                    let path_or_url =
-                        manifest_file
-                            .into_path_or_url()
-                            .context(ParsePathOrUrlSnafu {
-                                path_or_url: manifest_file.clone(),
-                            })?;
+                    let path_or_url = manifest_file
+                        .into_path_or_url()
+                        .context(ParsePathOrUrlSnafu)?;
 
                     let manifests = transfer_client
                         .get(&path_or_url, &Template::new(parameters))

--- a/rust/stackable-cockpit/src/platform/stack/spec.rs
+++ b/rust/stackable-cockpit/src/platform/stack/spec.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
+use stackable_operator::kvp::Labels;
 use tracing::{debug, info, instrument, log::warn};
 
 #[cfg(feature = "openapi")]
@@ -162,6 +163,8 @@ impl StackSpec {
                 release_list,
                 &install_parameters.operator_namespace,
                 &install_parameters.product_namespace,
+                transfer_client,
+                install_parameters.labels.clone(),
             )
             .await?;
         }
@@ -184,6 +187,8 @@ impl StackSpec {
         release_list: release::ReleaseList,
         operator_namespace: &str,
         product_namespace: &str,
+        transfer_client: &xfer::Client,
+        labels: Labels,
     ) -> Result<(), Error> {
         info!("Trying to install release {}", self.release);
 
@@ -196,7 +201,14 @@ impl StackSpec {
 
         // Install the release
         release
-            .install(&self.operators, &[], operator_namespace)
+            .install(
+                &self.operators,
+                &[],
+                operator_namespace,
+                transfer_client,
+                labels,
+            )
+            .await
             .context(InstallReleaseSnafu)
     }
 

--- a/rust/stackable-cockpit/src/utils/mod.rs
+++ b/rust/stackable-cockpit/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod params;
 pub mod path;
 pub mod string;
 pub mod templating;
+pub mod url;
 
 /// Returns the name of the operator used in the Helm repository.
 pub fn operator_chart_name(name: &str) -> String {

--- a/rust/stackable-cockpit/src/utils/path.rs
+++ b/rust/stackable-cockpit/src/utils/path.rs
@@ -11,8 +11,8 @@ pub enum PathOrUrl {
 
 #[derive(Debug, Snafu)]
 pub enum PathOrUrlParseError {
-    #[snafu(display("failed to parse URL"))]
-    UrlParse { source: ParseError },
+    #[snafu(display("failed to parse url {url:?}"))]
+    UrlParse { source: ParseError, url: String },
 }
 
 pub trait IntoPathOrUrl: Sized {
@@ -89,7 +89,7 @@ impl FromStr for PathOrUrl {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with("https://") || s.starts_with("http://") {
-            let url = Url::parse(s).context(UrlParseSnafu)?;
+            let url = Url::parse(s).context(UrlParseSnafu { url: s.to_string() })?;
             return Ok(Self::Url(url));
         }
 

--- a/rust/stackable-cockpit/src/utils/url.rs
+++ b/rust/stackable-cockpit/src/utils/url.rs
@@ -1,0 +1,5 @@
+use crate::constants::{OPERATOR_HELM_VALUE_BASE_URL, OPERATOR_HELM_VALUE_PATH};
+
+pub fn operator_values_yaml_url(operator_name: &str) -> String {
+    format!("{OPERATOR_HELM_VALUE_BASE_URL}{operator_name}-operator/{OPERATOR_HELM_VALUE_PATH}{operator_name}-operator/values.yaml")
+}

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -16,6 +16,7 @@ stackable-operator.workspace = true
 clap_complete.workspace = true
 clap.workspace = true
 comfy-table.workspace = true
+const_format.workspace = true
 directories.workspace = true
 dotenvy.workspace = true
 indexmap.workspace = true

--- a/rust/stackablectl/src/cli/mod.rs
+++ b/rust/stackablectl/src/cli/mod.rs
@@ -19,9 +19,9 @@ use crate::{
     args::{CommonFileArgs, CommonRepoArgs},
     cmds::{cache, completions, demo, operator, release, stack, stacklet},
     constants::{
-        ENV_KEY_DEMO_FILES, ENV_KEY_RELEASE_FILES, ENV_KEY_STACK_FILES, REMOTE_DEMO_FILE,
-        REMOTE_RELEASE_FILE, REMOTE_STACK_FILE, USER_DIR_APPLICATION_NAME,
-        USER_DIR_ORGANIZATION_NAME, USER_DIR_QUALIFIER,
+        DEMO_FILE_URL, ENV_KEY_DEMO_FILES, ENV_KEY_RELEASE_FILES, ENV_KEY_STACK_FILES,
+        RELEASE_FILE_URL, STACK_FILE_URL, USER_DIR_APPLICATION_NAME, USER_DIR_ORGANIZATION_NAME,
+        USER_DIR_QUALIFIER,
     },
     output::{ErrorContext, Output, ResultContext},
 };
@@ -90,7 +90,7 @@ impl Cli {
     /// the default demo file URL, [`REMOTE_DEMO_FILE`], files provided by the ENV variable [`ENV_KEY_DEMO_FILES`], and
     /// lastly, files provided by the CLI argument `--demo-file`.
     pub fn get_demo_files(&self) -> Result<Vec<PathOrUrl>, PathOrUrlParseError> {
-        let mut files = get_files(REMOTE_DEMO_FILE, ENV_KEY_DEMO_FILES)?;
+        let mut files = get_files(DEMO_FILE_URL, ENV_KEY_DEMO_FILES)?;
 
         let arg_files = self.files.demo_files.clone().into_paths_or_urls()?;
         files.extend(arg_files);
@@ -107,7 +107,7 @@ impl Cli {
     /// the default stack file URL, [`REMOTE_STACK_FILE`], files provided by the ENV variable [`ENV_KEY_STACK_FILES`],
     /// and lastly, files provided by the CLI argument `--stack-file`.
     pub fn get_stack_files(&self) -> Result<Vec<PathOrUrl>, PathOrUrlParseError> {
-        let mut files = get_files(REMOTE_STACK_FILE, ENV_KEY_STACK_FILES)?;
+        let mut files = get_files(STACK_FILE_URL, ENV_KEY_STACK_FILES)?;
 
         let arg_files = self.files.stack_files.clone().into_paths_or_urls()?;
         files.extend(arg_files);
@@ -119,7 +119,7 @@ impl Cli {
     /// combines the default demo file URL, [`REMOTE_RELEASE_FILE`], files provided by the ENV variable
     /// [`ENV_KEY_RELEASE_FILES`], and lastly, files provided by the CLI argument `--release-file`.
     pub fn get_release_files(&self) -> Result<Vec<PathOrUrl>, PathOrUrlParseError> {
-        let mut files = get_files(REMOTE_RELEASE_FILE, ENV_KEY_RELEASE_FILES)?;
+        let mut files = get_files(RELEASE_FILE_URL, ENV_KEY_RELEASE_FILES)?;
 
         let arg_files = self.files.release_files.clone().into_paths_or_urls()?;
         files.extend(arg_files);
@@ -184,7 +184,7 @@ impl Cli {
         cache.auto_purge().await.unwrap();
 
         match &self.subcommand {
-            Commands::Operator(args) => args.run(self).await.context(OperatorSnafu),
+            Commands::Operator(args) => args.run(self, cache).await.context(OperatorSnafu),
             Commands::Release(args) => args.run(self, cache).await.context(ReleaseSnafu),
             Commands::Stack(args) => args.run(self, cache).await.context(StackSnafu),
             Commands::Stacklet(args) => args.run(self).await.context(StackletSnafu),

--- a/rust/stackablectl/src/constants.rs
+++ b/rust/stackablectl/src/constants.rs
@@ -1,19 +1,20 @@
+use const_format::concatcp;
+
 pub const ENV_KEY_RELEASE_FILES: &str = "STACKABLE_RELEASE_FILES";
 pub const ENV_KEY_STACK_FILES: &str = "STACKABLE_STACK_FILES";
 pub const ENV_KEY_DEMO_FILES: &str = "STACKABLE_DEMO_FILES";
 
-pub const REMOTE_DEMO_FILE: &str =
-    "https://raw.githubusercontent.com/stackabletech/demos/main/demos/demos-v2.yaml";
+pub const DEMO_STACK_BASE_URL: &str = "https://raw.githubusercontent.com/stackabletech/demos/main/";
+pub const RELEASE_BASE_URL: &str = "https://raw.githubusercontent.com/stackabletech/release/main/";
+pub const REPO_BASE_URL: &str = "https://repo.stackable.tech/repository/";
 
-pub const REMOTE_STACK_FILE: &str =
-    "https://raw.githubusercontent.com/stackabletech/demos/main/stacks/stacks-v2.yaml";
+pub const STACK_FILE_URL: &str = concatcp!(DEMO_STACK_BASE_URL, "stacks/stacks-v2.yaml");
+pub const DEMO_FILE_URL: &str = concatcp!(DEMO_STACK_BASE_URL, "demos/demos-v2.yaml");
+pub const RELEASE_FILE_URL: &str = concatcp!(RELEASE_BASE_URL, "releases.yaml");
 
-pub const REMOTE_RELEASE_FILE: &str =
-    "https://raw.githubusercontent.com/stackabletech/release/main/releases.yaml";
-
-pub const HELM_REPO_URL_STABLE: &str = "https://repo.stackable.tech/repository/helm-stable/";
-pub const HELM_REPO_URL_TEST: &str = "https://repo.stackable.tech/repository/helm-test/";
-pub const HELM_REPO_URL_DEV: &str = "https://repo.stackable.tech/repository/helm-dev/";
+pub const HELM_REPO_URL_STABLE: &str = concatcp!(REPO_BASE_URL, "helm-stable/");
+pub const HELM_REPO_URL_TEST: &str = concatcp!(REPO_BASE_URL, "helm-test/");
+pub const HELM_REPO_URL_DEV: &str = concatcp!(REPO_BASE_URL, "helm-dev/");
 
 pub const USER_DIR_APPLICATION_NAME: &str = "stackablectl";
 pub const USER_DIR_ORGANIZATION_NAME: &str = "Stackable";


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/188

This adds the ability to add labels to deployed operators using the newly introduced `labels` key in each operator Helm `values.yaml` file.

This feature is **cannot** be used directly by `stackablectl` users, but instead the tool sets labels automatically based on the command executed.

---

**EDIT:** Encountered an issue with `DynamicValues`. The `secret-operator` doesn't include the `resources` key in its `values.yaml` file. How do we proceed?