### PR TITLE
ci: Fork awareness

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,4 +33,3 @@
 - [ ] Proper release label has been added
 ```
 
-Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)

--- a/.github/workflows/pr_cockpit.yml
+++ b/.github/workflows/pr_cockpit.yml
@@ -106,8 +106,12 @@ jobs:
       # Recreate charts and publish charts and docker image. The "-e" is needed as we want to override the
       # default value in the makefile if called from this action, but not otherwise (i.e. when called locally).
       # This is needed for the HELM_REPO variable.
+      - name: Build Docker Image and Helm Chart
+        run: make -e build
       - name: Publish Docker Image and Helm Chart
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: make -e publish
       - id: printtag
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         name: Output Image Name and Tag
         run: echo "IMAGE_TAG=$(make -e print-docker-tag)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr_cockpit.yml
+++ b/.github/workflows/pr_cockpit.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           submodules: recursive
-
+      - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28 # tag=v25
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e # v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ regenerate-nix:
 
 build: regenerate-charts regenerate-nix helm-package docker-build
 
-publish: build docker-publish helm-publish
+publish: docker-publish helm-publish
 
 run-dev:
 	kubectl apply -f deploy/stackable-operators-ns.yaml

--- a/default.nix
+++ b/default.nix
@@ -142,6 +142,7 @@ rec {
 
   regenerateNixLockfiles = pkgs.writeScriptBin "regenerate-nix-lockfiles"
     ''
+      #!/usr/bin/env bash
       set -euo pipefail
       echo Running crate2nix
       ${crate2nix}/bin/crate2nix generate


### PR DESCRIPTION
# Description

Split the `build` and `publish` make targets and CI steps so that fork PRs don't fail on publish (due to not having github secret access for registry login).

Similar changes made in operator-templating:
- https://github.com/stackabletech/operator-templating/pull/334
- https://github.com/stackabletech/operator-templating/pull/336
