### PR TITLE
chore: Release stackablectl-24.3.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,4 +32,3 @@
 - [ ] Feature Tracker has been updated
 - [ ] Proper release label has been added
 ```
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.3.1"
+version = "24.3.2"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ clean: chart-clean
 regenerate-charts: chart-clean compile-chart
 
 regenerate-nix:
-	nix run -f . regenerateNixLockfiles 
+	nix run -f . regenerateNixLockfiles
 
 build: regenerate-charts regenerate-nix helm-package docker-build
 

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -1,7 +1,7 @@
 = Installation
 :page-aliases: stable@stackablectl::installation.adoc
 
-:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.3.1
+:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.3.2
 :fish-comp-loations: https://fishshell.com/docs/current/completions.html#where-to-put-completions
 
 == Using Pre-Compiled Binaries
@@ -17,9 +17,9 @@ rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.1/stackablectl-x86_64-unknown-linux-gnu
+wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-x86_64-unknown-linux-gnu
 # or
-curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.1/stackablectl-x86_64-unknown-linux-gnu
+wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-aarch64-unknown-linux-gnu
 ----
 
 Mark the binary as executable:
@@ -39,9 +39,9 @@ then rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.1/stackablectl-x86_64-apple-darwin
+wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-x86_64-apple-darwin
 # or
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.1/stackablectl-aarch64-apple-darwin
+wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-aarch64-apple-darwin
 ----
 
 Mark the binary as executable:

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -17,9 +17,9 @@ rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-x86_64-unknown-linux-gnu
+curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-x86_64-unknown-linux-gnu
 # or
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-aarch64-unknown-linux-gnu
+curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-aarch64-unknown-linux-gnu
 ----
 
 Mark the binary as executable:
@@ -39,9 +39,9 @@ then rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-x86_64-apple-darwin
+curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-x86_64-apple-darwin
 # or
-wget -O stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-aarch64-apple-darwin
+curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.2/stackablectl-aarch64-apple-darwin
 ----
 
 Mark the binary as executable:

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.3.1" 
+.TH stackablectl 1  "stackablectl 24.3.2" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -98,6 +98,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.3.1
+v24.3.2
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.3.2] - 2024-04-25
+
 ### Added
 
 - Add pre-built binary for `aarch64-unknown-linux-gnu` ([#232]).

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.3.1"
+version = "24.3.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
_(PR also includes a few pre-commit fixes)_

## [24.3.2] - 2024-04-25

### Added

- Add pre-built binary for `aarch64-unknown-linux-gnu` ([#232]).

### Changed

- Bump Rust dependencies ([#233]).

[#232]: https://github.com/stackabletech/stackable-cockpit/pull/232
[#233]: https://github.com/stackabletech/stackable-cockpit/pull/233