### PR TITLE
chore: Release stackablectl-24.3.3

### DIFF
--- a/.github/workflows/pr_cockpit-web.yml
+++ b/.github/workflows/pr_cockpit-web.yml
@@ -21,6 +21,18 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn --cwd web run build
 
+  eslint:
+    name: Run web linting via ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 18
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn --cwd web run lint
+
   prettier:
     name: Validate web formatting
     runs-on: ubuntu-latest
@@ -37,4 +49,4 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            core.setFailed('web/ contains unformatted code, run `pnpm prettier . --write` and re-commit!')
+            core.setFailed('web/ contains unformatted code, run `yarn --cwd web run format --write` and re-commit!')

--- a/.github/workflows/pr_reviewdog.yml
+++ b/.github/workflows/pr_reviewdog.yml
@@ -18,19 +18,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  eslint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-        with:
-          version: 7.26.1
-          run_install: true
-      - uses: reviewdog/action-eslint@423672b7acbb75ee34d3e37aff30949ddc8350e3 # v1.24.0
-        with:
-          workdir: web
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   flake8:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.3.2"
+version = "24.3.3"
 dependencies = [
  "clap",
  "clap_complete",

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.3.2" 
+.TH stackablectl 1  "stackablectl 24.3.3" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -98,6 +98,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.3.2
+v24.3.3
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.3.3] - 2024-05-13
+
+- Bump Rust, Go and Node dependencies ([#238]).
+
+[#238]: https://github.com/stackabletech/stackable-cockpit/pull/238
+
 ## [24.3.2] - 2024-04-25
 
 ### Added

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.3.2"
+version = "24.3.3"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

Releases `stackablectl-24.3.3` to include the bumped dependencies from #238.

```[tasklist]
# Reviewer
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
