### PR TITLE
chore: Avoid unnecessary k8s::Client creations

### DIFF
--- a/rust/stackable-cockpit/src/platform/cluster/resource_request.rs
+++ b/rust/stackable-cockpit/src/platform/cluster/resource_request.rs
@@ -91,12 +91,8 @@ impl ResourceRequests {
     /// Validates the struct [`ResourceRequests`] by comparing the required
     /// resources to the available ones in the current cluster. `object_name`
     /// should be `stack` or `demo`.
-    pub async fn validate_cluster_size(&self, object_name: &str) -> Result<()> {
-        let kube_client = Client::new().await.context(KubeClientCreateSnafu)?;
-        let cluster_info = kube_client
-            .get_cluster_info()
-            .await
-            .context(ClusterInfoSnafu)?;
+    pub async fn validate_cluster_size(&self, client: &Client, object_name: &str) -> Result<()> {
+        let cluster_info = client.get_cluster_info().await.context(ClusterInfoSnafu)?;
 
         let stack_cpu =
             CpuQuantity::try_from(&self.cpu).context(ParseCpuResourceRequirementsSnafu)?;

--- a/rust/stackable-cockpit/src/platform/credentials.rs
+++ b/rust/stackable-cockpit/src/platform/credentials.rs
@@ -4,7 +4,7 @@ use kube::{core::DynamicObject, ResourceExt};
 use serde::Serialize;
 use snafu::{OptionExt, ResultExt, Snafu};
 
-use crate::utils::k8s;
+use crate::utils::k8s::{self, Client};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -34,7 +34,7 @@ impl Display for Credentials {
 /// and/or `password_key` are not found or the product does not provide
 /// any credentials.
 pub async fn get(
-    kube_client: &k8s::Client,
+    client: &Client,
     product_name: &str,
     stacklet: &DynamicObject,
 ) -> Result<Option<Credentials>> {
@@ -56,7 +56,7 @@ pub async fn get(
                 .as_str()
                 .context(NoSecretSnafu)?;
 
-            kube_client
+            client
                 .get_credentials_from_secret(
                     secret_name,
                     &stacklet.namespace().unwrap(),
@@ -71,7 +71,7 @@ pub async fn get(
                 .as_str()
                 .context(NoSecretSnafu)?;
 
-            kube_client
+            client
                 .get_credentials_from_secret(
                     secret_name,
                     &stacklet.namespace().unwrap(),

--- a/rust/stackable-cockpit/src/platform/demo/spec.rs
+++ b/rust/stackable-cockpit/src/platform/demo/spec.rs
@@ -14,10 +14,13 @@ use crate::{
         release::ReleaseList,
         stack::{self, StackInstallParameters, StackList},
     },
-    utils::params::{
-        IntoParameters, IntoParametersError, Parameter, RawParameter, RawParameterParseError,
+    utils::{
+        k8s::Client,
+        params::{
+            IntoParameters, IntoParametersError, Parameter, RawParameter, RawParameterParseError,
+        },
     },
-    xfer::{self, Client},
+    xfer,
 };
 
 pub type RawDemoParameterParseError = RawParameterParseError;
@@ -94,7 +97,11 @@ impl DemoSpec {
     /// - Does the demo support to be installed in the requested namespace?
     /// - Does the cluster have enough resources available to run this demo?
     #[instrument(skip_all)]
-    pub async fn check_prerequisites(&self, product_namespace: &str) -> Result<(), Error> {
+    pub async fn check_prerequisites(
+        &self,
+        client: &Client,
+        product_namespace: &str,
+    ) -> Result<(), Error> {
         debug!("Checking prerequisites before installing demo");
 
         // Returns an error if the demo doesn't support to be installed in the
@@ -109,7 +116,10 @@ impl DemoSpec {
         // Checks if the available cluster resources are sufficient to deploy
         // the demo.
         if let Some(resource_requests) = &self.resource_requests {
-            if let Err(err) = resource_requests.validate_cluster_size("demo").await {
+            if let Err(err) = resource_requests
+                .validate_cluster_size(client, "demo")
+                .await
+            {
                 match err {
                     ResourceRequestsError::ValidationErrors { errors } => {
                         for error in errors {
@@ -129,7 +139,8 @@ impl DemoSpec {
         stack_list: StackList,
         release_list: ReleaseList,
         install_parameters: DemoInstallParameters,
-        transfer_client: &Client,
+        client: &Client,
+        transfer_client: &xfer::Client,
     ) -> Result<(), Error> {
         // Get the stack spec based on the name defined in the demo spec
         let stack = stack_list.get(&self.stack).context(NoSuchStackSnafu {
@@ -137,7 +148,7 @@ impl DemoSpec {
         })?;
 
         // Check demo prerequisites
-        self.check_prerequisites(&install_parameters.product_namespace)
+        self.check_prerequisites(client, &install_parameters.product_namespace)
             .await?;
 
         let stack_install_parameters = StackInstallParameters {
@@ -151,12 +162,17 @@ impl DemoSpec {
         };
 
         stack
-            .install(release_list, stack_install_parameters, transfer_client)
+            .install(
+                release_list,
+                stack_install_parameters,
+                client,
+                transfer_client,
+            )
             .await
             .context(InstallStackSnafu)?;
 
         // Install demo manifests
-        self.prepare_manifests(install_parameters, transfer_client)
+        self.prepare_manifests(install_parameters, client, transfer_client)
             .await
     }
 
@@ -164,6 +180,7 @@ impl DemoSpec {
     async fn prepare_manifests(
         &self,
         install_params: DemoInstallParameters,
+        client: &Client,
         transfer_client: &xfer::Client,
     ) -> Result<(), Error> {
         info!("Installing demo manifests");
@@ -179,6 +196,7 @@ impl DemoSpec {
             &params,
             &install_params.product_namespace,
             install_params.labels,
+            client,
             transfer_client,
         )
         .await

--- a/rust/stackable-cockpit/src/platform/namespace.rs
+++ b/rust/stackable-cockpit/src/platform/namespace.rs
@@ -1,6 +1,6 @@
-use snafu::{ResultExt, Snafu};
+use snafu::Snafu;
 
-use crate::utils::k8s;
+use crate::utils::k8s::{self, Client};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -13,9 +13,7 @@ pub enum Error {
 
 /// Creates a namespace with `name` if needed (not already present in the
 /// cluster).
-pub async fn create_if_needed(name: String) -> Result<(), Error> {
-    let client = k8s::Client::new().await.context(KubeClientCreateSnafu)?;
-
+pub async fn create_if_needed(client: &Client, name: String) -> Result<(), Error> {
     client
         .create_namespace_if_needed(name)
         .await

--- a/rust/stackable-cockpit/src/platform/stacklet/grafana.rs
+++ b/rust/stackable-cockpit/src/platform/stacklet/grafana.rs
@@ -9,21 +9,18 @@ use crate::{
     utils::k8s::{Client, ListParamsExt, ProductLabel},
 };
 
-pub(super) async fn list(
-    kube_client: &Client,
-    namespace: Option<&str>,
-) -> Result<Vec<Stacklet>, Error> {
+pub(super) async fn list(client: &Client, namespace: Option<&str>) -> Result<Vec<Stacklet>, Error> {
     let mut stacklets = Vec::new();
 
     let params = ListParams::from_product("grafana", None, ProductLabel::Name);
-    let services = kube_client
+    let services = client
         .list_services(namespace, &params)
         .await
         .context(KubeClientFetchSnafu)?;
 
     for service in services {
         let service_name = service.name_any();
-        let endpoints = get_endpoint_urls(kube_client, &service, &service_name)
+        let endpoints = get_endpoint_urls(client, &service, &service_name)
             .await
             .context(ServiceFetchSnafu)?;
 

--- a/rust/stackable-cockpit/src/platform/stacklet/minio.rs
+++ b/rust/stackable-cockpit/src/platform/stacklet/minio.rs
@@ -9,15 +9,12 @@ use crate::{
     utils::k8s::Client,
 };
 
-pub(super) async fn list(
-    kube_client: &Client,
-    namespace: Option<&str>,
-) -> Result<Vec<Stacklet>, Error> {
+pub(super) async fn list(client: &Client, namespace: Option<&str>) -> Result<Vec<Stacklet>, Error> {
     let mut stacklets = Vec::new();
 
     // The helm-chart uses `app` instead of `app.kubernetes.io/app`, so we can't use `ListParams::from_product` here
     let params = ListParams::default().labels("app=minio,app.kubernetes.io/managed-by=Helm");
-    let services = kube_client
+    let services = client
         .list_services(namespace, &params)
         .await
         .context(KubeClientFetchSnafu)?;
@@ -28,7 +25,7 @@ pub(super) async fn list(
 
     for service in console_services {
         let service_name = service.name_any();
-        let endpoints = get_endpoint_urls(kube_client, service, &service_name)
+        let endpoints = get_endpoint_urls(client, service, &service_name)
             .await
             .context(ServiceFetchSnafu)?;
 

--- a/rust/stackable-cockpit/src/platform/stacklet/mod.rs
+++ b/rust/stackable-cockpit/src/platform/stacklet/mod.rs
@@ -69,11 +69,11 @@ pub async fn list_stacklets(
     client: &Client,
     namespace: Option<&str>,
 ) -> Result<Vec<Stacklet>, Error> {
-    let mut stacklets = list_stackable_stacklets(&client, namespace).await?;
-    stacklets.extend(grafana::list(&client, namespace).await?);
-    stacklets.extend(minio::list(&client, namespace).await?);
-    stacklets.extend(opensearch::list(&client, namespace).await?);
-    stacklets.extend(prometheus::list(&client, namespace).await?);
+    let mut stacklets = list_stackable_stacklets(client, namespace).await?;
+    stacklets.extend(grafana::list(client, namespace).await?);
+    stacklets.extend(minio::list(client, namespace).await?);
+    stacklets.extend(opensearch::list(client, namespace).await?);
+    stacklets.extend(prometheus::list(client, namespace).await?);
 
     Ok(stacklets)
 }
@@ -99,7 +99,7 @@ pub async fn get_credentials_for_product(
         }
     };
 
-    let credentials = match credentials::get(&client, product_name, &product_cluster).await {
+    let credentials = match credentials::get(client, product_name, &product_cluster).await {
         Ok(credentials) => credentials,
         Err(credentials::Error::NoSecret) => None,
         Err(credentials::Error::KubeClientFetch { source }) => {

--- a/rust/stackable-cockpit/src/platform/stacklet/mod.rs
+++ b/rust/stackable-cockpit/src/platform/stacklet/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     constants::PRODUCT_NAMES,
     platform::{credentials, service},
     utils::{
-        k8s::{self, ConditionsExt},
+        k8s::{self, Client, ConditionsExt},
         string::Casing,
     },
 };
@@ -65,27 +65,27 @@ pub enum Error {
 /// namespaces are returned. If `namespace` is [`Some`], only stacklets installed
 /// in the specified namespace are returned. The `options` allow further
 /// customization of the returned information.
-pub async fn list_stacklets(namespace: Option<&str>) -> Result<Vec<Stacklet>, Error> {
-    let kube_client = k8s::Client::new().await.context(KubeClientCreateSnafu)?;
-
-    let mut stacklets = list_stackable_stacklets(&kube_client, namespace).await?;
-    stacklets.extend(grafana::list(&kube_client, namespace).await?);
-    stacklets.extend(minio::list(&kube_client, namespace).await?);
-    stacklets.extend(opensearch::list(&kube_client, namespace).await?);
-    stacklets.extend(prometheus::list(&kube_client, namespace).await?);
+pub async fn list_stacklets(
+    client: &Client,
+    namespace: Option<&str>,
+) -> Result<Vec<Stacklet>, Error> {
+    let mut stacklets = list_stackable_stacklets(&client, namespace).await?;
+    stacklets.extend(grafana::list(&client, namespace).await?);
+    stacklets.extend(minio::list(&client, namespace).await?);
+    stacklets.extend(opensearch::list(&client, namespace).await?);
+    stacklets.extend(prometheus::list(&client, namespace).await?);
 
     Ok(stacklets)
 }
 
 pub async fn get_credentials_for_product(
+    client: &Client,
     namespace: &str,
     object_name: &str,
     product_name: &str,
 ) -> Result<Option<credentials::Credentials>, Error> {
-    let kube_client = k8s::Client::new().await.context(KubeClientCreateSnafu)?;
-
     let product_gvk = gvk_from_product_name(product_name);
-    let product_cluster = match kube_client
+    let product_cluster = match client
         .get_namespaced_object(namespace, object_name, &product_gvk)
         .await
         .context(KubeClientFetchSnafu)?
@@ -99,7 +99,7 @@ pub async fn get_credentials_for_product(
         }
     };
 
-    let credentials = match credentials::get(&kube_client, product_name, &product_cluster).await {
+    let credentials = match credentials::get(&client, product_name, &product_cluster).await {
         Ok(credentials) => credentials,
         Err(credentials::Error::NoSecret) => None,
         Err(credentials::Error::KubeClientFetch { source }) => {
@@ -111,14 +111,14 @@ pub async fn get_credentials_for_product(
 }
 
 async fn list_stackable_stacklets(
-    kube_client: &k8s::Client,
+    client: &Client,
     namespace: Option<&str>,
 ) -> Result<Vec<Stacklet>, Error> {
     let product_list = build_products_gvk_list(PRODUCT_NAMES);
     let mut stacklets = Vec::new();
 
     for (product_name, product_gvk) in product_list {
-        let objects = match kube_client
+        let objects = match client
             .list_objects(&product_gvk, namespace)
             .await
             .context(KubeClientFetchSnafu)?
@@ -148,7 +148,7 @@ async fn list_stackable_stacklets(
             };
 
             let endpoints =
-                service::get_endpoints(kube_client, product_name, &object_name, &object_namespace)
+                service::get_endpoints(client, product_name, &object_name, &object_namespace)
                     .await
                     .context(ServiceFetchSnafu)?;
 

--- a/rust/stackable-cockpit/src/platform/stacklet/opensearch.rs
+++ b/rust/stackable-cockpit/src/platform/stacklet/opensearch.rs
@@ -9,21 +9,18 @@ use crate::{
     utils::k8s::{Client, ListParamsExt, ProductLabel},
 };
 
-pub(super) async fn list(
-    kube_client: &Client,
-    namespace: Option<&str>,
-) -> Result<Vec<Stacklet>, Error> {
+pub(super) async fn list(client: &Client, namespace: Option<&str>) -> Result<Vec<Stacklet>, Error> {
     let mut stacklets = Vec::new();
 
     let params = ListParams::from_product("opensearch-dashboards", None, ProductLabel::Name);
-    let services = kube_client
+    let services = client
         .list_services(namespace, &params)
         .await
         .context(KubeClientFetchSnafu)?;
 
     for service in services {
         let service_name = service.name_any();
-        let endpoints = get_endpoint_urls(kube_client, &service, &service_name)
+        let endpoints = get_endpoint_urls(client, &service, &service_name)
             .await
             .context(ServiceFetchSnafu)?;
 

--- a/rust/stackable-cockpit/src/platform/stacklet/prometheus.rs
+++ b/rust/stackable-cockpit/src/platform/stacklet/prometheus.rs
@@ -9,22 +9,19 @@ use crate::{
     utils::k8s::Client,
 };
 
-pub(super) async fn list(
-    kube_client: &Client,
-    namespace: Option<&str>,
-) -> Result<Vec<Stacklet>, Error> {
+pub(super) async fn list(client: &Client, namespace: Option<&str>) -> Result<Vec<Stacklet>, Error> {
     let mut stacklets = Vec::new();
 
     // The helm-chart uses `app` instead of `app.kubernetes.io/app`, so we can't use `ListParams::from_product` here
     let params = ListParams::default().labels("app=kube-prometheus-stack-prometheus");
-    let services = kube_client
+    let services = client
         .list_services(namespace, &params)
         .await
         .context(KubeClientFetchSnafu)?;
 
     for service in services {
         let service_name = service.name_any();
-        let endpoints = get_endpoint_urls(kube_client, &service, &service_name)
+        let endpoints = get_endpoint_urls(client, &service, &service_name)
             .await
             .context(ServiceFetchSnafu)?;
 

--- a/rust/stackable-cockpitd/src/handlers/stacklets.rs
+++ b/rust/stackable-cockpitd/src/handlers/stacklets.rs
@@ -9,15 +9,16 @@ pub fn router() -> Router {
 }
 
 /// Retrieves all stacklets.
+// TODO: Add proper error handling
 #[utoipa::path(get, path = "/stacklets", responses(
     (status = 200, body = Vec<Stacklet>),
 ))]
 pub async fn get_stacklets() -> Json<Vec<Stacklet>> {
-    let client = Client::new().await.unwrap();
+    let client = Client::new().await.expect("failed to construct k8s client");
 
     Json(
         platform::stacklet::list_stacklets(&client, None)
             .await
-            .unwrap(),
+            .expect("failed to list stacklets"),
     )
 }

--- a/rust/stackable-cockpitd/src/handlers/stacklets.rs
+++ b/rust/stackable-cockpitd/src/handlers/stacklets.rs
@@ -1,5 +1,5 @@
 use axum::{routing::get, Json, Router};
-use stackable_cockpit::platform;
+use stackable_cockpit::{platform, utils::k8s::Client};
 
 pub use stackable_cockpit::platform::stacklet::Stacklet;
 
@@ -13,5 +13,11 @@ pub fn router() -> Router {
     (status = 200, body = Vec<Stacklet>),
 ))]
 pub async fn get_stacklets() -> Json<Vec<Stacklet>> {
-    Json(platform::stacklet::list_stacklets(None).await.unwrap())
+    let client = Client::new().await.unwrap();
+
+    Json(
+        platform::stacklet::list_stacklets(&client, None)
+            .await
+            .unwrap(),
+    )
 }

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- chore: Avoid unnecessary `k8s::Client` creations ([#295]).
+
 ## [24.3.3] - 2024-05-13
 
 - Bump Rust, Go and Node dependencies ([#238]).
 
 [#238]: https://github.com/stackabletech/stackable-cockpit/pull/238
+[#295]: https://github.com/stackabletech/stackable-cockpit/pull/295
 
 ## [24.3.2] - 2024-04-25
 


### PR DESCRIPTION
# Description

Needs https://github.com/stackabletech/stackable-cockpit/pull/294 to properly work

Shows a significant speedup (e.g. when installing to IONOS) from 13s to 7.6s, the speedup is probably much higher on mobile networks (ask me after my next trip to Hamburg ^^)

```bash
➜  demos git:(observability-stack) ✗ time ~/stackable/stackable-cockpit/target/debug/stackablectl demo in end-to-end-security
   WARN  RUNNING DISCOVERY
    at rust/stackable-cockpit/src/utils/k8s/client.rs:80


Installed demo 'end-to-end-security'

Use "stackablectl operator installed" to display the installed operators.
Use "stackablectl stacklet list" to display the installed stacklets.
~/stackable/stackable-cockpit/target/debug/stackablectl demo in   2,72s user 0,55s system 43% cpu 7,430 total
➜  demos git:(observability-stack) ✗ time stackablectl demo in end-to-end-security          

Installed demo 'end-to-end-security'

Use "stackablectl operator installed" to display the installed operators.
Use "stackablectl stacklet list" to display the installed stacklets.
stackablectl demo in end-to-end-security  2,77s user 0,63s system 24% cpu 13,635 total
➜  demos git:(observability-stack) ✗ time ~/stackable/stackable-cockpit/target/debug/stackablectl demo in end-to-end-security
   WARN  RUNNING DISCOVERY
    at rust/stackable-cockpit/src/utils/k8s/client.rs:80


Installed demo 'end-to-end-security'

Use "stackablectl operator installed" to display the installed operators.
Use "stackablectl stacklet list" to display the installed stacklets.
~/stackable/stackable-cockpit/target/debug/stackablectl demo in   2,67s user 0,56s system 41% cpu 7,837 total
➜  demos git:(observability-stack) ✗ time stackablectl demo in end-to-end-security                                           

Installed demo 'end-to-end-security'

Use "stackablectl operator installed" to display the installed operators.
Use "stackablectl stacklet list" to display the installed stacklets.
stackablectl demo in end-to-end-security  2,73s user 0,61s system 27% cpu 12,115 total
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
