### PR TITLE
fix: Remove colons from error messages

### DIFF
--- a/rust/helm-sys/build.rs
+++ b/rust/helm-sys/build.rs
@@ -13,10 +13,10 @@ enum Error {
     #[snafu(display("Failed to find env var"))]
     EnvVarNotFound { source: VarError },
 
-    #[snafu(display("Unsupported GOARCH: {arch}"))]
+    #[snafu(display("Unsupported GOARCH ({arch})"))]
     UnsupportedGoArch { arch: String },
 
-    #[snafu(display("Unsupported GOOS: {os}"))]
+    #[snafu(display("Unsupported GOOS ({os})"))]
     UnsupportedGoOs { os: String },
 }
 

--- a/rust/stackable-cockpit/src/engine/kind/mod.rs
+++ b/rust/stackable-cockpit/src/engine/kind/mod.rs
@@ -30,10 +30,10 @@ pub enum Error {
     #[snafu(display("failed to run kind command"))]
     CommandFailedToRun { source: std::io::Error },
 
-    #[snafu(display("kind command executed, but returned error: {error}"))]
+    #[snafu(display("failed to successfuly run kind command ({error})"))]
     CommandErroredOut { error: String },
 
-    #[snafu(display("missing required binary: {binary}"))]
+    #[snafu(display("missing required binary {binary:?}"))]
     MissingBinary { binary: String },
 
     #[snafu(display("failed to determine if Docker is running"))]

--- a/rust/stackable-cockpit/src/engine/minikube/mod.rs
+++ b/rust/stackable-cockpit/src/engine/minikube/mod.rs
@@ -17,7 +17,7 @@ pub enum Error {
         cluster_name: String,
     },
 
-    #[snafu(display("missing required binary: {binary}"))]
+    #[snafu(display("missing required binary {binary:?}"))]
     MissingBinary { binary: String },
 
     #[snafu(display("failed to execute Minikube command"))]

--- a/rust/stackable-cockpit/src/helm.rs
+++ b/rust/stackable-cockpit/src/helm.rs
@@ -63,13 +63,13 @@ pub enum Error {
     #[snafu(display("failed to add Helm repo ({error})"))]
     AddRepo { error: String },
 
-    #[snafu(display("failed to list Helm releases: {error}"))]
+    #[snafu(display("failed to list Helm releases ({error})"))]
     ListReleases { error: String },
 
     #[snafu(display("failed to install Helm release"))]
     InstallRelease { source: InstallReleaseError },
 
-    #[snafu(display("failed to uninstall Helm release: {error}"))]
+    #[snafu(display("failed to uninstall Helm release ({error})"))]
     UninstallRelease { error: String },
 }
 
@@ -93,7 +93,7 @@ pub enum InstallReleaseError {
     /// This error indicates that there was an Helm error. The error it self
     /// is not typed, as the error is a plain string coming directly from the
     /// FFI bindings.
-    #[snafu(display("helm error: {error}"))]
+    #[snafu(display("helm FFI library call failed ({error})"))]
     HelmWrapper { error: String },
 }
 

--- a/rust/stackable-cockpit/src/platform/operator/mod.rs
+++ b/rust/stackable-cockpit/src/platform/operator/mod.rs
@@ -43,7 +43,7 @@ pub enum SpecParseError {
     #[snafu(display("empty operator spec input"))]
     EmptyInput,
 
-    #[snafu(display("invalid operator name: '{name}'"))]
+    #[snafu(display("invalid operator name {name:?}"))]
     InvalidName { name: String },
 }
 

--- a/rust/stackable-cockpit/src/utils/k8s/client.rs
+++ b/rust/stackable-cockpit/src/utils/k8s/client.rs
@@ -50,6 +50,13 @@ pub enum Error {
     #[snafu(display("failed to deploy manifest because type of object {object:?} is not set"))]
     ObjectType { object: DynamicObject },
 
+    #[snafu(display("failed to deploy manifest because GVK {group}/{kind}@{version} cannot be resolved",
+        group = gvk.group,
+        version = gvk.version,
+        kind = gvk.kind
+    ))]
+    DiscoveryResolve { gvk: GroupVersionKind },
+
     #[snafu(display("failed to convert byte string into UTF-8 string"))]
     ByteStringConvert { source: FromUtf8Error },
 

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove colons from error messages, because the snafu report removes all
+  content after the colon which results in loss of detail ([#300]).
+
+[#300]: https://github.com/stackabletech/stackable-cockpit/pull/300
+
 ## [24.3.4] - 2024-05-28
 
 ### Fixed

--- a/rust/xtask/src/docs.rs
+++ b/rust/xtask/src/docs.rs
@@ -11,7 +11,7 @@ const DOCS_BASE_PATH: &str = "docs/modules/stackablectl/partials/commands";
 
 #[derive(Debug, Snafu)]
 pub enum GenDocsError {
-    #[snafu(display("No such subcommand: {name}"))]
+    #[snafu(display("subcommand {name:?} not found"))]
     NoSuchSubcommand { name: String },
 
     #[snafu(display("io error"))]

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -142,6 +142,8 @@ export interface components {
   pathItems: never;
 }
 
+export type $defs = Record<string, never>;
+
 export type external = Record<string, never>;
 
 export interface operations {


### PR DESCRIPTION
The snafu report cleans up error messages by removing any content after a colon is encountered in the error message. This also messes up the output of structs when the Debug output is used. This was causing an issue when we failed to resolve a GVK.