### PR TITLE
fix: update Cargo.nix version and pre-commit hook improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ Cargo.nix linguist-generated
 yarn.lock linguist-generated
 nix/** linguist-generated
 go.sum linguist-generated
+gomod2nix.toml linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,6 @@
 htpasswd
 .yarn
 
-# Nix
-gomod2nix.toml
-Cargo.nix
-crate-hashes.json
-
 # Misc
 /demos
 /stacks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,30 +50,35 @@ repos:
     hooks:
       - id: gen-man
         name: gen-man
+        files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-man
         stages: [commit, merge-commit, manual]
         pass_filenames: false
       - id: gen-comp
         name: gen-comp
+        files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-comp
         stages: [commit, merge-commit, manual]
         pass_filenames: false
       - id: gen-openapi
         name: gen-openapi
+        files: ^web/
         language: system
         entry: cargo xtask gen-openapi
         stages: [commit, merge-commit, manual]
         pass_filenames: false
       - id: gen-ctl-readme
         name: gen-ctl-readme
+        files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-ctl-readme
         stages: [commit, merge-commit, manual]
         pass_filenames: false
       - id: gen-docs
         name: gen-docs
+        files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-docs
         stages: [commit, merge-commit, manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ---
 # See https://pre-commit.com for more information
+fail_fast: true
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         # Generated file
         exclude: ^web/src/api/schema.d.ts|extra/.*$
       - id: end-of-file-fixer
+        exclude: Cargo.nix
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
       - id: detect-private-key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,3 +78,10 @@ repos:
         entry: cargo xtask gen-docs
         stages: [commit, merge-commit, manual]
         pass_filenames: false
+      - id: gen-cargo-nix
+        name: gen-cargo-nix
+        files: ^Cargo\.lock|go\.mod$
+        language: system
+        entry: make regenerate-nix
+        stages: [commit, merge-commit, manual]
+        pass_filename: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: trailing-whitespace
         # Generated file
-        exclude: ^web/src/api/schema.d.ts|extra/.*$
+        exclude: ^web/src/api/schema\.d\.ts|extra/.*$
       - id: end-of-file-fixer
         exclude: Cargo.nix
       - id: detect-aws-credentials

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9465,7 +9465,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.3.4";
+        version = "24.3.5";
         edition = "2021";
         crateBin = [
           {

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -142,8 +142,6 @@ export interface components {
   pathItems: never;
 }
 
-export type $defs = Record<string, never>;
-
 export type external = Record<string, never>;
 
 export interface operations {

--- a/web/src/api/schema.d.ts
+++ b/web/src/api/schema.d.ts
@@ -142,6 +142,8 @@ export interface components {
   pathItems: never;
 }
 
+export type $defs = Record<string, never>;
+
 export type external = Record<string, never>;
 
 export interface operations {


### PR DESCRIPTION
> [!IMPORTANT]
> We probably want to retag `24.3.5` once this is merged.

# Description

Without Cargo.nix being updated (via make regenerate-nix), the old version was still appearing in the new binary.

Additional improvements to speed up the pre-commit hook feedback loop.