### PR TITLE
fix: Remove string cleaning in error report

### DIFF
--- a/rust/stackablectl/src/output/mod.rs
+++ b/rust/stackablectl/src/output/mod.rs
@@ -1,3 +1,9 @@
+//! This module contains helper structs and functions to render the CLI output
+//! based on templates. These templates allow dynamic composition of the output.
+//! The output offers sections for pre, post and command hints, as well as
+//! success and error output. The [`ErrorReport`] serves as an alternative to
+//! snafu's [`Report`](snafu::Report).
+
 use std::{
     fmt::Write,
     ops::{Deref, DerefMut},

--- a/rust/stackablectl/src/output/mod.rs
+++ b/rust/stackablectl/src/output/mod.rs
@@ -59,16 +59,7 @@ where
         let mut index = 1;
 
         while let Some(source) = error.source() {
-            let source_string = source.to_string();
-
-            let cleaned = if let Some((cleaned, _)) = source_string.split_once(':') {
-                cleaned
-            } else {
-                &source_string
-            };
-
-            writeln!(report, " {}: {}", index, cleaned)?;
-
+            writeln!(report, " {}: {}", index, source)?;
             error = source;
             index += 1;
         }


### PR DESCRIPTION
For now, let's remove the cleaning of error messages, because it hides too much detail. In the future, we should improve how these error messages are rendered in the terminal.