### PR TITLE
chore: Release stackablectl-24.3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,4 +90,4 @@ repos:
         language: system
         entry: make regenerate-nix
         stages: [commit, merge-commit, manual]
-        pass_filename: false
+        pass_filenames: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.3.5"
+version = "24.3.6"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9465,7 +9465,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.3.5";
+        version = "24.3.6";
         edition = "2021";
         crateBin = [
           {

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ clean: chart-clean
 regenerate-charts: chart-clean compile-chart
 
 regenerate-nix:
-	nix run -f . regenerateNixLockfiles
+	nix run --extra-experimental-features flakes -f . regenerateNixLockfiles
 
 build: regenerate-charts regenerate-nix helm-package docker-build
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ clean: chart-clean
 
 regenerate-charts: chart-clean compile-chart
 
+# The explicit '--extra-experimental-features flakes' parameter was added,
+# because the command requires Flakes to be enabled, but most non-Nix users
+# don't enable them via the global nix rc file.
 regenerate-nix:
 	nix run --extra-experimental-features flakes -f . regenerateNixLockfiles
 

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -1,7 +1,7 @@
 = Installation
 :page-aliases: stable@stackablectl::installation.adoc
 
-:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.3.5
+:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.3.6
 :fish-comp-loations: https://fishshell.com/docs/current/completions.html#where-to-put-completions
 
 == Using Pre-Compiled Binaries
@@ -20,9 +20,9 @@ rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.5/stackablectl-x86_64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-x86_64-unknown-linux-gnu
 # or
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.5/stackablectl-aarch64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-aarch64-unknown-linux-gnu
 ----
 
 Mark the binary as executable:
@@ -44,9 +44,9 @@ then rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.5/stackablectl-x86_64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-x86_64-apple-darwin
 # or
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.5/stackablectl-aarch64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-aarch64-apple-darwin
 ----
 
 Mark the binary as executable:

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.3.5" 
+.TH stackablectl 1  "stackablectl 24.3.6" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -98,6 +98,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.3.5
+v24.3.6
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.3.6] - 2024-06-24
+
+### Fixed
+
+- Remove error message trimming in error report ([#303]).
+
+[#303]: https://github.com/stackabletech/stackable-cockpit/pull/303
+
 ## [24.3.5] - 2024-06-17
 
 ### Fixed

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.3.5"
+version = "24.3.6"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release includes:

### Fixed

- Remove error message trimming in error report ([#303]).

[#303]: https://github.com/stackabletech/stackable-cockpit/pull/303