### PR TITLE
chore: Release stackablectl-24.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.3.6"
+version = "24.7.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9804,7 +9804,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.3.6";
+        version = "24.7.0";
         edition = "2021";
         crateBin = [
           {

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -1,7 +1,7 @@
 = Installation
 :page-aliases: stable@stackablectl::installation.adoc
 
-:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.3.6
+:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.7.0
 :fish-comp-loations: https://fishshell.com/docs/current/completions.html#where-to-put-completions
 
 == Using Pre-Compiled Binaries
@@ -20,9 +20,9 @@ rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-x86_64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-x86_64-unknown-linux-gnu
 # or
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-aarch64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-aarch64-unknown-linux-gnu
 ----
 
 Mark the binary as executable:
@@ -44,9 +44,9 @@ then rename the file to `stackablectl`. You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-x86_64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-x86_64-apple-darwin
 # or
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.3.6/stackablectl-aarch64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-aarch64-apple-darwin
 ----
 
 Mark the binary as executable:

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.3.6" 
+.TH stackablectl 1  "stackablectl 24.7.0" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -98,6 +98,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.3.6
+v24.7.0
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.7.0] - 2024-07-23
+
 ### Changed
 
 - helm-sys: Bump Go dependencies ([#307]).

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.3.6"
+version = "24.7.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Releases stackablectl-24.7.0 which includes:

### Changed

- helm-sys: Bump Go dependencies ([#307]).
- Bump Rust dependencies ([#307]).

### Fixed

- helm-sys: Double the helm timeout to 20m ([#306]).

[#306]: https://github.com/stackabletech/stackable-cockpit/pull/306
[#307]: https://github.com/stackabletech/stackable-cockpit/pull/307