### PR TITLE
docs(stackablectl): simplify install steps

### DIFF
--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -33,14 +33,21 @@ $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/rel
 $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-aarch64-unknown-linux-gnu
 ----
 
-Mark the binary as executable:
+Install the binary into a directory in the `$PATH`, and make it executable:
+
+NOTE: If you have a directory in your `$HOME` for user binaries, you can remove `sudo`, and change the directory to that.
 
 [source,console]
 ----
-$ chmod +x stackablectl
+$ sudo install -m 755 -t /usr/local/bin stackablectl
 ----
 
-Then, make sure it is present in your `$PATH`, like `/usr/local/bin`.
+Test that it works:
+
+[source,console]
+----
+$ stackablectl --version
+----
 --
 
 macOS::
@@ -64,15 +71,27 @@ $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/rel
 $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-aarch64-apple-darwin
 ----
 
-Mark the binary as executable:
+Install the binary into a directory in the `$PATH`, and make it executable:
+
+NOTE: If you have a directory in your `$HOME` for user binaries, you can remove `sudo`, and change the directory to that.
 
 [source,console]
 ----
-$ chmod +x stackablectl
+$ sudo install -m 755 -t /usr/local/bin stackablectl
 ----
 
+Test that it works:
+
+[source,console]
+----
+$ stackablectl --version
+----
+
+[TIP]
+====
 If macOS denies the execution of `stackablectl` go to Settings -> Security & Privacy -> General. Here you will see a pop
 up asking if you want to allow access for `stackablectl`. You must allow access.
+====
 --
 
 Windows::
@@ -106,6 +125,13 @@ access it from anywhere if you like:
 [source,console]
 ----
 $ cp target/release/stackablectl /usr/local/bin
+----
+
+Test that it works:
+
+[source,console]
+----
+$ stackablectl --version
 ----
 
 [#shell-comps]

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -15,13 +15,21 @@ manual building steps can be found in xref:#building-from-source[this] section.
 Linux::
 +
 --
-Download the `stackablectl-x86_64-unknown-linux-gnu` binary file from the link:{latest-release}[latest release], then
-rename the file to `stackablectl`. You can also use the following command:
+Download the appropriate binary file for your architecture, `stackablectl-x86_64-unknown-linux-gnu` for Intel-based devices or
+`stackablectl-aarch64-unknown-linux-gnu` for ARM-based devices from the link:{latest-release}[latest release],
+then rename the file to `stackablectl`. You can also use the following command:
+
+*x86_64* (amd64):
 
 [source,console]
 ----
 $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-x86_64-unknown-linux-gnu
-# or
+----
+
+**aarch64** (arm64):
+
+[source,console]
+----
 $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-aarch64-unknown-linux-gnu
 ----
 
@@ -38,14 +46,21 @@ Then, make sure it is present in your `$PATH`, like `/usr/local/bin`.
 macOS::
 +
 --
-Download the `stackablectl-x86_64-apple-darwin` binary file for Intel-based devices or the
-`stackablectl-aarch64-apple-darwin` binary file for ARM-based devices from the link:{latest-release}[latest release],
+Download the appropriate binary file for your architecture, `stackablectl-x86_64-apple-darwin` for Intel-based devices or
+`stackablectl-aarch64-apple-darwin` for ARM-based devices from the link:{latest-release}[latest release],
 then rename the file to `stackablectl`. You can also use the following command:
+
+*x86_64* (amd64):
 
 [source,console]
 ----
 $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-x86_64-apple-darwin
-# or
+----
+
+**aarch64** (arm64):
+
+[source,console]
+----
 $ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.7.0/stackablectl-aarch64-apple-darwin
 ----
 


### PR DESCRIPTION
# Description

- Split install commands so that the copy button doesn't join them with `&&` (when only one needs to be run).
- Replace the `chmod` steps with the `install`. @fhennig I can revert that if you want to keep the instructions the same as they were.
- Windows: add a step to test the command
  I won't fix the windows install instructions, eg:
  - Do we assume CMD, PowerShell, or WSL2? (`cp` vs `copy`, `/usr/local/bin` vs `%USERPROFILE%\bin`)
  - Adding `%USERPROFILE%\bin` to the user's `PATH` variable? And restarting the shell, or logging out and in again?

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Documentation added or updated
```
