### PR TITLE
chore: Release stackblectl-24.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.7.0"
+version = "24.7.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9790,7 +9790,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.7.0";
+        version = "24.7.1";
         edition = "2021";
         crateBin = [
           {

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.7.0" 
+.TH stackablectl 1  "stackablectl 24.7.1" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -98,6 +98,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.7.0
+v24.7.1
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.7.1] - 2024-08-15
+
 ### Changed
 
 - helm-sys: Bump Go dependencies to fix critical vulnerability in
   `github.com/docker/docker`, See [CVE-2024-41110] ([#313]).
 
+### Fixed
+
+- nix: Fix broken build ([#311], [#314]).
+
+[#311]: https://github.com/stackabletech/stackable-cockpit/pull/311
 [#313]: https://github.com/stackabletech/stackable-cockpit/pull/313
+[#314]: https://github.com/stackabletech/stackable-cockpit/pull/314
 [CVE-2024-41110]: https://github.com/advisories/GHSA-v23v-6jw2-98fq
 
 ## [24.7.0] - 2024-07-23

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.7.0"
+version = "24.7.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases `stackablectl-24.7.1` which includes:

### Changed

- helm-sys: Bump Go dependencies to fix critical vulnerability in `github.com/docker/docker`, See [CVE-2024-41110] ([#313]).

### Fixed

- nix: Fix broken build ([#311], [#314]).

[#311]: https://github.com/stackabletech/stackable-cockpit/pull/311
[#313]: https://github.com/stackabletech/stackable-cockpit/pull/313
[#314]: https://github.com/stackabletech/stackable-cockpit/pull/314
[CVE-2024-41110]: https://github.com/advisories/GHSA-v23v-6jw2-98fq