### PR TITLE
fix(ci): Install hadolint in pre-commit workflow

### DIFF
--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt,clippy
+      - name: Setup Hadolint
+        shell: bash
+        run: |
+          LOCATION="$HOME/.local/bin/hadolint"
+          SYSTEM=$(UNAME -s)
+          ARCH=$(uname -m)
+
+          curl -sL -o "${LOCATION}" "https://github.com/hadolint/hadolint/releases/download/v1.17.6/hadolint-$SYSTEM-$ARCH"
+          chmod 700 "${LOCATION}"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Hadolint
         shell: bash
         run: |
-          set -euo pipefail
+          set -xeuo pipefail
 
           LOCATION="$HOME/.local/bin/hadolint"
           SYSTEM=$(uname -s)

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN_VERSION: "1.80.1"
+  HADOLINT_VERSION: "v1.17.6"
 
 jobs:
   pre-commit:
@@ -29,7 +30,7 @@ jobs:
           SYSTEM=$(uname -s)
           ARCH=$(uname -m)
 
-          curl -sL -o "${LOCATION}" "https://github.com/hadolint/hadolint/releases/download/v1.17.6/hadolint-$SYSTEM-$ARCH"
+          curl -sL -o "${LOCATION}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
           chmod 700 "${LOCATION}"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: |
           LOCATION="$HOME/.local/bin/hadolint"
-          SYSTEM=$(UNAME -s)
+          SYSTEM=$(uname -s)
           ARCH=$(uname -m)
 
           curl -sL -o "${LOCATION}" "https://github.com/hadolint/hadolint/releases/download/v1.17.6/hadolint-$SYSTEM-$ARCH"

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -xeuo pipefail
 
-          LOCATION="$HOME/.local/bin/hadolint"
+          LOCATION="$HOME/hadolint"
           SYSTEM=$(uname -s)
           ARCH=$(uname -m)
 

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.12'
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          components: rustfmt,clippy
       - name: Setup Hadolint
         shell: bash
         run: |

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -19,21 +19,22 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.12'
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
-          components: rustfmt,clippy
       - name: Setup Hadolint
         shell: bash
         run: |
-          set -xeuo pipefail
+          set -euo pipefail
 
-          LOCATION="$HOME/hadolint"
+          LOCATION_DIR="$HOME/.local/bin"
+          LOCATION_BIN="$LOCATION_DIR/hadolint"
+
           SYSTEM=$(uname -s)
           ARCH=$(uname -m)
 
-          curl -sL -o "${LOCATION}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
-          chmod 700 "${LOCATION}"
+          mkdir -p "$LOCATION_DIR"
+          curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
+          chmod 700 "${LOCATION_BIN}"
+
+          echo "$LOCATION_DIR" >> "$GITHUB_PATH"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Setup Hadolint
         shell: bash
         run: |
+          set -euo pipefail
+
           LOCATION="$HOME/.local/bin/hadolint"
           SYSTEM=$(uname -s)
           ARCH=$(uname -m)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 ---
 fail_fast: true
+
+default_language_version:
+  node: system
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # 4.6.0


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/637

This fixes two things:

- Install the hadolint binary to be able to run the pre-commit hook
- Set the default language version of `node` to `system`. This fixes issues on NixOS systems.