### PR TITLE
chore: Release stackablectl-24.11.0

### DIFF
--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -16,29 +16,10 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
         with:
-          python-version: '3.12'
-      - uses: dtolnay/rust-toolchain@master
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: stackabletech/actions/run-pre-commit@9bd13255f286e4b7a654617268abe1b2f37c3e0a # v0.3.0
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
-          components: rustfmt,clippy
-      - name: Setup Hadolint
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          LOCATION_DIR="$HOME/.local/bin"
-          LOCATION_BIN="$LOCATION_DIR/hadolint"
-
-          SYSTEM=$(uname -s)
-          ARCH=$(uname -m)
-
-          mkdir -p "$LOCATION_DIR"
-          curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
-          chmod 700 "${LOCATION_BIN}"
-
-          echo "$LOCATION_DIR" >> "$GITHUB_PATH"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"
+          rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          hadolint: ${{ env.HADOLINT_VERSION }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-man
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
 
       - id: gen-comp
@@ -66,7 +66,7 @@ repos:
         files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-comp
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
 
       - id: gen-openapi
@@ -74,7 +74,7 @@ repos:
         files: ^web/
         language: system
         entry: cargo xtask gen-openapi
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
 
       - id: gen-ctl-readme
@@ -82,7 +82,7 @@ repos:
         files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-ctl-readme
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
 
       - id: gen-docs
@@ -90,7 +90,7 @@ repos:
         files: ^rust/stackablectl/
         language: system
         entry: cargo xtask gen-docs
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
 
       - id: gen-cargo-nix
@@ -98,5 +98,5 @@ repos:
         files: ^Cargo\.lock|go\.mod$
         language: system
         entry: make regenerate-nix
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.7.1"
+version = "24.11.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9929,7 +9929,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.7.1";
+        version = "24.11.0";
         edition = "2021";
         crateBin = [
           {

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.7.1" 
+.TH stackablectl 1  "stackablectl 24.11.0" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -98,6 +98,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.7.1
+v24.11.0
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.11.0] - 2024-11-18
+
 ### Changed
 
 - Bump Rust dependencies to fix critical vulnerability in `quinn-proto`, see

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.7.1"
+version = "24.11.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/647.

It should be noted that the release date is 2024-11-18 (next Monday at the time of writing) and it is required to push a tag after merging this PR into main.

---

This release includes:

### Changed

- Bump Rust dependencies to fix critical vulnerability in `quinn-proto`, see [CVE-2024-45311] ([#318]).
- Bump Rust toolchain version to 1.80.1 ([#318]).

[#318]: https://github.com/stackabletech/stackable-cockpit/pull/318
[CVE-2024-45311]: https://github.com/advisories/GHSA-vr26-jcq5-fjj8