### PR TITLE
feat: Add shell completions for Nushell and Elvish

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     hooks:
       - id: shellcheck
         args: ["--severity=info"]
+        exclude: '^extra/completions/'
 
   - repo: https://github.com/rhysd/actionlint
     rev: 62dc61a45fc95efe8c800af7a557ab0b9165d63b # 1.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,6 +3111,7 @@ version = "24.11.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "comfy-table",
  "directories",
  "dotenvy",
@@ -4199,6 +4210,7 @@ version = "0.0.0-dev"
 dependencies = [
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "clap_mangen",
  "once_cell",
  "regex",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1818,6 +1818,36 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
+      "clap_complete_nushell" = rec {
+        crateName = "clap_complete_nushell";
+        version = "4.5.4";
+        edition = "2021";
+        sha256 = "0xvnl61gnc3j76b9y50y35zvg7fls30i7lyb43fmsvncj3kh4n9i";
+        dependencies = [
+          {
+            name = "clap";
+            packageId = "clap";
+            usesDefaultFeatures = false;
+            features = [ "std" ];
+          }
+          {
+            name = "clap_complete";
+            packageId = "clap_complete";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "clap";
+            packageId = "clap";
+            usesDefaultFeatures = false;
+            features = [ "std" "help" ];
+          }
+        ];
+        features = {
+          "unstable-shell-tests" = [ "dep:completest" "dep:completest-nu" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
       "clap_derive" = rec {
         crateName = "clap_derive";
         version = "4.5.13";
@@ -9953,6 +9983,10 @@ rec {
             packageId = "clap_complete";
           }
           {
+            name = "clap_complete_nushell";
+            packageId = "clap_complete_nushell";
+          }
+          {
             name = "comfy-table";
             packageId = "comfy-table";
             features = [ "custom_styling" ];
@@ -14463,6 +14497,10 @@ rec {
           {
             name = "clap_complete";
             packageId = "clap_complete";
+          }
+          {
+            name = "clap_complete_nushell";
+            packageId = "clap_complete_nushell";
           }
           {
             name = "clap_mangen";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bindgen = "0.70.1"
 cc = "1.0.83"
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
+clap_complete_nushell = "4.5"
 comfy-table = { version = "7.1", features = ["custom_styling"] }
 directories = "5.0"
 dotenvy = "0.15"

--- a/docs/modules/stackablectl/partials/commands/completions.adoc
+++ b/docs/modules/stackablectl/partials/commands/completions.adoc
@@ -7,6 +7,7 @@ Usage: stackablectl completions [OPTIONS] <COMMAND>
 
 Commands:
   bash     Generate shell completions for Bash
+  elvish   Generate shell completions for Elvish
   fish     Generate shell completions for Fish
   nushell  Generate shell completions for Nushell
   zsh      Generate shell completions for ZSH

--- a/docs/modules/stackablectl/partials/commands/completions.adoc
+++ b/docs/modules/stackablectl/partials/commands/completions.adoc
@@ -6,10 +6,11 @@ Generate shell completions for this tool
 Usage: stackablectl completions [OPTIONS] <COMMAND>
 
 Commands:
-  bash  Generate shell completions for Bash
-  fish  Generate shell completions for Fish
-  zsh   Generate shell completions for ZSH
-  help  Print this message or the help of the given subcommand(s)
+  bash     Generate shell completions for Bash
+  fish     Generate shell completions for Fish
+  nushell  Generate shell completions for Nushell
+  zsh      Generate shell completions for ZSH
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
   -l, --log-level <LOG_LEVEL>

--- a/extra/completions/_stackablectl
+++ b/extra/completions/_stackablectl
@@ -960,6 +960,27 @@ _arguments "${_arguments_options[@]}" : \
 '--version[Print version]' \
 && ret=0
 ;;
+(nushell)
+_arguments "${_arguments_options[@]}" : \
+'-l+[Log level this application uses]:LOG_LEVEL: ' \
+'--log-level=[Log level this application uses]:LOG_LEVEL: ' \
+'*-d+[Provide one or more additional (custom) demo file(s)]:DEMO_FILE:_files' \
+'*--demo-file=[Provide one or more additional (custom) demo file(s)]:DEMO_FILE:_files' \
+'*-s+[Provide one or more additional (custom) stack file(s)]:STACK_FILE:_files' \
+'*--stack-file=[Provide one or more additional (custom) stack file(s)]:STACK_FILE:_files' \
+'*-r+[Provide one or more additional (custom) release file(s)]:RELEASE_FILE:_files' \
+'*--release-file=[Provide one or more additional (custom) release file(s)]:RELEASE_FILE:_files' \
+'--helm-repo-stable=[Provide a custom Helm stable repository URL]:URL:_urls' \
+'--helm-repo-test=[Provide a custom Helm test repository URL]:URL:_urls' \
+'--helm-repo-dev=[Provide a custom Helm dev repository URL]:URL:_urls' \
+'--no-cache[Do not cache the remote (default) demo, stack and release files]' \
+'--offline[Do not request any remote files via the network]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
 (zsh)
 _arguments "${_arguments_options[@]}" : \
 '-l+[Log level this application uses]:LOG_LEVEL: ' \
@@ -998,6 +1019,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (fish)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(nushell)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1330,6 +1355,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(nushell)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (zsh)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1442,6 +1471,7 @@ _stackablectl__completions_commands() {
     local commands; commands=(
 'bash:Generate shell completions for Bash' \
 'fish:Generate shell completions for Fish' \
+'nushell:Generate shell completions for Nushell' \
 'zsh:Generate shell completions for ZSH' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -1462,6 +1492,7 @@ _stackablectl__completions__help_commands() {
     local commands; commands=(
 'bash:Generate shell completions for Bash' \
 'fish:Generate shell completions for Fish' \
+'nushell:Generate shell completions for Nushell' \
 'zsh:Generate shell completions for ZSH' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
@@ -1482,10 +1513,20 @@ _stackablectl__completions__help__help_commands() {
     local commands; commands=()
     _describe -t commands 'stackablectl completions help help commands' commands "$@"
 }
+(( $+functions[_stackablectl__completions__help__nushell_commands] )) ||
+_stackablectl__completions__help__nushell_commands() {
+    local commands; commands=()
+    _describe -t commands 'stackablectl completions help nushell commands' commands "$@"
+}
 (( $+functions[_stackablectl__completions__help__zsh_commands] )) ||
 _stackablectl__completions__help__zsh_commands() {
     local commands; commands=()
     _describe -t commands 'stackablectl completions help zsh commands' commands "$@"
+}
+(( $+functions[_stackablectl__completions__nushell_commands] )) ||
+_stackablectl__completions__nushell_commands() {
+    local commands; commands=()
+    _describe -t commands 'stackablectl completions nushell commands' commands "$@"
 }
 (( $+functions[_stackablectl__completions__zsh_commands] )) ||
 _stackablectl__completions__zsh_commands() {
@@ -1590,6 +1631,7 @@ _stackablectl__help__completions_commands() {
     local commands; commands=(
 'bash:Generate shell completions for Bash' \
 'fish:Generate shell completions for Fish' \
+'nushell:Generate shell completions for Nushell' \
 'zsh:Generate shell completions for ZSH' \
     )
     _describe -t commands 'stackablectl help completions commands' commands "$@"
@@ -1603,6 +1645,11 @@ _stackablectl__help__completions__bash_commands() {
 _stackablectl__help__completions__fish_commands() {
     local commands; commands=()
     _describe -t commands 'stackablectl help completions fish commands' commands "$@"
+}
+(( $+functions[_stackablectl__help__completions__nushell_commands] )) ||
+_stackablectl__help__completions__nushell_commands() {
+    local commands; commands=()
+    _describe -t commands 'stackablectl help completions nushell commands' commands "$@"
 }
 (( $+functions[_stackablectl__help__completions__zsh_commands] )) ||
 _stackablectl__help__completions__zsh_commands() {

--- a/extra/completions/_stackablectl
+++ b/extra/completions/_stackablectl
@@ -939,6 +939,27 @@ _arguments "${_arguments_options[@]}" : \
 '--version[Print version]' \
 && ret=0
 ;;
+(elvish)
+_arguments "${_arguments_options[@]}" : \
+'-l+[Log level this application uses]:LOG_LEVEL: ' \
+'--log-level=[Log level this application uses]:LOG_LEVEL: ' \
+'*-d+[Provide one or more additional (custom) demo file(s)]:DEMO_FILE:_files' \
+'*--demo-file=[Provide one or more additional (custom) demo file(s)]:DEMO_FILE:_files' \
+'*-s+[Provide one or more additional (custom) stack file(s)]:STACK_FILE:_files' \
+'*--stack-file=[Provide one or more additional (custom) stack file(s)]:STACK_FILE:_files' \
+'*-r+[Provide one or more additional (custom) release file(s)]:RELEASE_FILE:_files' \
+'*--release-file=[Provide one or more additional (custom) release file(s)]:RELEASE_FILE:_files' \
+'--helm-repo-stable=[Provide a custom Helm stable repository URL]:URL:_urls' \
+'--helm-repo-test=[Provide a custom Helm test repository URL]:URL:_urls' \
+'--helm-repo-dev=[Provide a custom Helm dev repository URL]:URL:_urls' \
+'--no-cache[Do not cache the remote (default) demo, stack and release files]' \
+'--offline[Do not request any remote files via the network]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
 (fish)
 _arguments "${_arguments_options[@]}" : \
 '-l+[Log level this application uses]:LOG_LEVEL: ' \
@@ -1015,6 +1036,10 @@ _arguments "${_arguments_options[@]}" : \
         curcontext="${curcontext%:*:*}:stackablectl-completions-help-command-$line[1]:"
         case $line[1] in
             (bash)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(elvish)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1351,6 +1376,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(elvish)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (fish)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1470,6 +1499,7 @@ _stackablectl__cache__list_commands() {
 _stackablectl__completions_commands() {
     local commands; commands=(
 'bash:Generate shell completions for Bash' \
+'elvish:Generate shell completions for Elvish' \
 'fish:Generate shell completions for Fish' \
 'nushell:Generate shell completions for Nushell' \
 'zsh:Generate shell completions for ZSH' \
@@ -1482,6 +1512,11 @@ _stackablectl__completions__bash_commands() {
     local commands; commands=()
     _describe -t commands 'stackablectl completions bash commands' commands "$@"
 }
+(( $+functions[_stackablectl__completions__elvish_commands] )) ||
+_stackablectl__completions__elvish_commands() {
+    local commands; commands=()
+    _describe -t commands 'stackablectl completions elvish commands' commands "$@"
+}
 (( $+functions[_stackablectl__completions__fish_commands] )) ||
 _stackablectl__completions__fish_commands() {
     local commands; commands=()
@@ -1491,6 +1526,7 @@ _stackablectl__completions__fish_commands() {
 _stackablectl__completions__help_commands() {
     local commands; commands=(
 'bash:Generate shell completions for Bash' \
+'elvish:Generate shell completions for Elvish' \
 'fish:Generate shell completions for Fish' \
 'nushell:Generate shell completions for Nushell' \
 'zsh:Generate shell completions for ZSH' \
@@ -1502,6 +1538,11 @@ _stackablectl__completions__help_commands() {
 _stackablectl__completions__help__bash_commands() {
     local commands; commands=()
     _describe -t commands 'stackablectl completions help bash commands' commands "$@"
+}
+(( $+functions[_stackablectl__completions__help__elvish_commands] )) ||
+_stackablectl__completions__help__elvish_commands() {
+    local commands; commands=()
+    _describe -t commands 'stackablectl completions help elvish commands' commands "$@"
 }
 (( $+functions[_stackablectl__completions__help__fish_commands] )) ||
 _stackablectl__completions__help__fish_commands() {
@@ -1630,6 +1671,7 @@ _stackablectl__help__cache__list_commands() {
 _stackablectl__help__completions_commands() {
     local commands; commands=(
 'bash:Generate shell completions for Bash' \
+'elvish:Generate shell completions for Elvish' \
 'fish:Generate shell completions for Fish' \
 'nushell:Generate shell completions for Nushell' \
 'zsh:Generate shell completions for ZSH' \
@@ -1640,6 +1682,11 @@ _stackablectl__help__completions_commands() {
 _stackablectl__help__completions__bash_commands() {
     local commands; commands=()
     _describe -t commands 'stackablectl help completions bash commands' commands "$@"
+}
+(( $+functions[_stackablectl__help__completions__elvish_commands] )) ||
+_stackablectl__help__completions__elvish_commands() {
+    local commands; commands=()
+    _describe -t commands 'stackablectl help completions elvish commands' commands "$@"
 }
 (( $+functions[_stackablectl__help__completions__fish_commands] )) ||
 _stackablectl__help__completions__fish_commands() {

--- a/extra/completions/stackablectl.bash
+++ b/extra/completions/stackablectl.bash
@@ -60,6 +60,9 @@ _stackablectl() {
             stackablectl__completions,bash)
                 cmd="stackablectl__completions__bash"
                 ;;
+            stackablectl__completions,elvish)
+                cmd="stackablectl__completions__elvish"
+                ;;
             stackablectl__completions,fish)
                 cmd="stackablectl__completions__fish"
                 ;;
@@ -74,6 +77,9 @@ _stackablectl() {
                 ;;
             stackablectl__completions__help,bash)
                 cmd="stackablectl__completions__help__bash"
+                ;;
+            stackablectl__completions__help,elvish)
+                cmd="stackablectl__completions__help__elvish"
                 ;;
             stackablectl__completions__help,fish)
                 cmd="stackablectl__completions__help__fish"
@@ -146,6 +152,9 @@ _stackablectl() {
                 ;;
             stackablectl__help__completions,bash)
                 cmd="stackablectl__help__completions__bash"
+                ;;
+            stackablectl__help__completions,elvish)
+                cmd="stackablectl__help__completions__elvish"
                 ;;
             stackablectl__help__completions,fish)
                 cmd="stackablectl__help__completions__fish"
@@ -874,7 +883,7 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__completions)
-            opts="-l -d -s -r -h -V --log-level --no-cache --offline --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version bash fish nushell zsh help"
+            opts="-l -d -s -r -h -V --log-level --no-cache --offline --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version bash elvish fish nushell zsh help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -998,6 +1007,130 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__completions__bash)
+            opts="-l -d -s -r -h -V --log-level --no-cache --offline --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --log-level)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --demo-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -d)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --stack-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -s)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --release-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -r)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --helm-repo-stable)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --helm-repo-test)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --helm-repo-dev)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        stackablectl__completions__elvish)
             opts="-l -d -s -r -h -V --log-level --no-cache --offline --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1246,7 +1379,7 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__completions__help)
-            opts="bash fish nushell zsh help"
+            opts="bash elvish fish nushell zsh help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1260,6 +1393,20 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__completions__help__bash)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        stackablectl__completions__help__elvish)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -2408,7 +2555,7 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__help__completions)
-            opts="bash fish nushell zsh"
+            opts="bash elvish fish nushell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2422,6 +2569,20 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__help__completions__bash)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        stackablectl__help__completions__elvish)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/extra/completions/stackablectl.bash
+++ b/extra/completions/stackablectl.bash
@@ -66,6 +66,9 @@ _stackablectl() {
             stackablectl__completions,help)
                 cmd="stackablectl__completions__help"
                 ;;
+            stackablectl__completions,nushell)
+                cmd="stackablectl__completions__nushell"
+                ;;
             stackablectl__completions,zsh)
                 cmd="stackablectl__completions__zsh"
                 ;;
@@ -77,6 +80,9 @@ _stackablectl() {
                 ;;
             stackablectl__completions__help,help)
                 cmd="stackablectl__completions__help__help"
+                ;;
+            stackablectl__completions__help,nushell)
+                cmd="stackablectl__completions__help__nushell"
                 ;;
             stackablectl__completions__help,zsh)
                 cmd="stackablectl__completions__help__zsh"
@@ -143,6 +149,9 @@ _stackablectl() {
                 ;;
             stackablectl__help__completions,fish)
                 cmd="stackablectl__help__completions__fish"
+                ;;
+            stackablectl__help__completions,nushell)
+                cmd="stackablectl__help__completions__nushell"
                 ;;
             stackablectl__help__completions,zsh)
                 cmd="stackablectl__help__completions__zsh"
@@ -865,7 +874,7 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__completions)
-            opts="-l -d -s -r -h -V --log-level --no-cache --offline --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version bash fish zsh help"
+            opts="-l -d -s -r -h -V --log-level --no-cache --offline --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version bash fish nushell zsh help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1237,7 +1246,7 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__completions__help)
-            opts="bash fish zsh help"
+            opts="bash fish nushell zsh help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1292,6 +1301,20 @@ _stackablectl() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        stackablectl__completions__help__nushell)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         stackablectl__completions__help__zsh)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
@@ -1299,6 +1322,130 @@ _stackablectl() {
                 return 0
             fi
             case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        stackablectl__completions__nushell)
+            opts="-l -d -s -r -h -V --log-level --no-cache --offline --demo-file --stack-file --release-file --helm-repo-stable --helm-repo-test --helm-repo-dev --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --log-level)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --demo-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -d)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --stack-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -s)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --release-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -r)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --helm-repo-stable)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --helm-repo-test)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --helm-repo-dev)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -2261,7 +2408,7 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__help__completions)
-            opts="bash fish zsh"
+            opts="bash fish nushell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2289,6 +2436,20 @@ _stackablectl() {
             return 0
             ;;
         stackablectl__help__completions__fish)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        stackablectl__help__completions__nushell)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/extra/completions/stackablectl.elv
+++ b/extra/completions/stackablectl.elv
@@ -1,0 +1,982 @@
+
+use builtin;
+use str;
+
+set edit:completion:arg-completer[stackablectl] = {|@words|
+    fn spaces {|n|
+        builtin:repeat $n ' ' | str:join ''
+    }
+    fn cand {|text desc|
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
+    }
+    var command = 'stackablectl'
+    for word $words[1..-1] {
+        if (str:has-prefix $word '-') {
+            break
+        }
+        set command = $command';'$word
+    }
+    var completions = [
+        &'stackablectl'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand operator 'Interact with single operator instead of the full platform'
+            cand release 'Interact with all operators of the platform which are released together'
+            cand stack 'Interact with stacks, which are ready-to-use product combinations'
+            cand stacklet 'Interact with deployed stacklets, which are bundles of resources and containers required to run the product'
+            cand demo 'Interact with demos, which are end-to-end usage demonstrations of the Stackable data platform'
+            cand completions 'Generate shell completions for this tool'
+            cand cache 'Interact with locally cached files'
+            cand experimental-debug 'EXPERIMENTAL: Launch a debug container for a Pod'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;operator'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand list 'List available operators'
+            cand describe 'Print out detailed operator information'
+            cand install 'Install one or more operators'
+            cand uninstall 'Uninstall one or more operators'
+            cand installed 'List installed operators'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;operator;list'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;operator;describe'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;operator;install'= {
+            cand --operator-namespace 'Namespace in the cluster used to deploy the operators'
+            cand --operator-ns 'Namespace in the cluster used to deploy the operators'
+            cand -c 'Type of local cluster to use for testing'
+            cand --cluster 'Type of local cluster to use for testing'
+            cand --cluster-name 'Name of the local cluster'
+            cand --cluster-nodes 'Number of total nodes in the local cluster'
+            cand --cluster-cp-nodes 'Number of control plane nodes in the local cluster'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;operator;uninstall'= {
+            cand --operator-namespace 'Namespace in the cluster used to deploy the operators'
+            cand --operator-ns 'Namespace in the cluster used to deploy the operators'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;operator;installed'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand --operator-namespace 'Namespace in the cluster used to deploy the operators'
+            cand --operator-ns 'Namespace in the cluster used to deploy the operators'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;operator;help'= {
+            cand list 'List available operators'
+            cand describe 'Print out detailed operator information'
+            cand install 'Install one or more operators'
+            cand uninstall 'Uninstall one or more operators'
+            cand installed 'List installed operators'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;operator;help;list'= {
+        }
+        &'stackablectl;operator;help;describe'= {
+        }
+        &'stackablectl;operator;help;install'= {
+        }
+        &'stackablectl;operator;help;uninstall'= {
+        }
+        &'stackablectl;operator;help;installed'= {
+        }
+        &'stackablectl;operator;help;help'= {
+        }
+        &'stackablectl;release'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand list 'List available releases'
+            cand describe 'Print out detailed release information'
+            cand install 'Install a specific release'
+            cand uninstall 'Uninstall a release'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;release;list'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;release;describe'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;release;install'= {
+            cand -i 'Whitelist of product operators to install'
+            cand --include 'Whitelist of product operators to install'
+            cand -e 'Blacklist of product operators to install'
+            cand --exclude 'Blacklist of product operators to install'
+            cand --operator-namespace 'Namespace in the cluster used to deploy the operators'
+            cand --operator-ns 'Namespace in the cluster used to deploy the operators'
+            cand -c 'Type of local cluster to use for testing'
+            cand --cluster 'Type of local cluster to use for testing'
+            cand --cluster-name 'Name of the local cluster'
+            cand --cluster-nodes 'Number of total nodes in the local cluster'
+            cand --cluster-cp-nodes 'Number of control plane nodes in the local cluster'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;release;uninstall'= {
+            cand --operator-namespace 'Namespace in the cluster used to deploy the operators'
+            cand --operator-ns 'Namespace in the cluster used to deploy the operators'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;release;help'= {
+            cand list 'List available releases'
+            cand describe 'Print out detailed release information'
+            cand install 'Install a specific release'
+            cand uninstall 'Uninstall a release'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;release;help;list'= {
+        }
+        &'stackablectl;release;help;describe'= {
+        }
+        &'stackablectl;release;help;install'= {
+        }
+        &'stackablectl;release;help;uninstall'= {
+        }
+        &'stackablectl;release;help;help'= {
+        }
+        &'stackablectl;stack'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand list 'List available stacks'
+            cand describe 'Describe a specific stack'
+            cand install 'Install a specific stack'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;stack;list'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;stack;describe'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;stack;install'= {
+            cand --stack-parameters 'List of parameters to use when installing the stack'
+            cand --parameters 'List of parameters to use when installing the stack'
+            cand -c 'Type of local cluster to use for testing'
+            cand --cluster 'Type of local cluster to use for testing'
+            cand --cluster-name 'Name of the local cluster'
+            cand --cluster-nodes 'Number of total nodes in the local cluster'
+            cand --cluster-cp-nodes 'Number of control plane nodes in the local cluster'
+            cand --operator-namespace 'Namespace where the operators are deployed'
+            cand --operator-ns 'Namespace where the operators are deployed'
+            cand -n 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand --product-namespace 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand --product-ns 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --skip-release 'Skip the installation of the release during the stack install process'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;stack;help'= {
+            cand list 'List available stacks'
+            cand describe 'Describe a specific stack'
+            cand install 'Install a specific stack'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;stack;help;list'= {
+        }
+        &'stackablectl;stack;help;describe'= {
+        }
+        &'stackablectl;stack;help;install'= {
+        }
+        &'stackablectl;stack;help;help'= {
+        }
+        &'stackablectl;stacklet'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand credentials 'Display credentials for a stacklet'
+            cand list 'List deployed stacklets'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;stacklet;credentials'= {
+            cand -n 'Namespace in the cluster used to deploy the products'
+            cand --product-namespace 'Namespace in the cluster used to deploy the products'
+            cand --product-ns 'Namespace in the cluster used to deploy the products'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;stacklet;list'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand --operator-namespace 'Namespace where the operators are deployed'
+            cand --operator-ns 'Namespace where the operators are deployed'
+            cand -n 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand --product-namespace 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand --product-ns 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;stacklet;help'= {
+            cand credentials 'Display credentials for a stacklet'
+            cand list 'List deployed stacklets'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;stacklet;help;credentials'= {
+        }
+        &'stackablectl;stacklet;help;list'= {
+        }
+        &'stackablectl;stacklet;help;help'= {
+        }
+        &'stackablectl;demo'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand list 'List available demos'
+            cand describe 'Print out detailed demo information'
+            cand install 'Install a specific demo'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;demo;list'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;demo;describe'= {
+            cand -o 'o'
+            cand --output 'output'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;demo;install'= {
+            cand --stack-parameters 'List of parameters to use when installing the stack'
+            cand --parameters 'List of parameters to use when installing the demo'
+            cand -c 'Type of local cluster to use for testing'
+            cand --cluster 'Type of local cluster to use for testing'
+            cand --cluster-name 'Name of the local cluster'
+            cand --cluster-nodes 'Number of total nodes in the local cluster'
+            cand --cluster-cp-nodes 'Number of control plane nodes in the local cluster'
+            cand --operator-namespace 'Namespace where the operators are deployed'
+            cand --operator-ns 'Namespace where the operators are deployed'
+            cand -n 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand --product-namespace 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand --product-ns 'Namespace where the products (e.g. stacks or demos) are deployed'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --skip-release 'Skip the installation of the release during the stack install process'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;demo;help'= {
+            cand list 'List available demos'
+            cand describe 'Print out detailed demo information'
+            cand install 'Install a specific demo'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;demo;help;list'= {
+        }
+        &'stackablectl;demo;help;describe'= {
+        }
+        &'stackablectl;demo;help;install'= {
+        }
+        &'stackablectl;demo;help;help'= {
+        }
+        &'stackablectl;completions'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand bash 'Generate shell completions for Bash'
+            cand elvish 'Generate shell completions for Elvish'
+            cand fish 'Generate shell completions for Fish'
+            cand nushell 'Generate shell completions for Nushell'
+            cand zsh 'Generate shell completions for ZSH'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;completions;bash'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;completions;elvish'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;completions;fish'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;completions;nushell'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;completions;zsh'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;completions;help'= {
+            cand bash 'Generate shell completions for Bash'
+            cand elvish 'Generate shell completions for Elvish'
+            cand fish 'Generate shell completions for Fish'
+            cand nushell 'Generate shell completions for Nushell'
+            cand zsh 'Generate shell completions for ZSH'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;completions;help;bash'= {
+        }
+        &'stackablectl;completions;help;elvish'= {
+        }
+        &'stackablectl;completions;help;fish'= {
+        }
+        &'stackablectl;completions;help;nushell'= {
+        }
+        &'stackablectl;completions;help;zsh'= {
+        }
+        &'stackablectl;completions;help;help'= {
+        }
+        &'stackablectl;cache'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+            cand list 'List cached files'
+            cand clean 'Clean cached files'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;cache;list'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;cache;clean'= {
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --old 'Only remove outdated files in the cache'
+            cand --outdated 'Only remove outdated files in the cache'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;cache;help'= {
+            cand list 'List cached files'
+            cand clean 'Clean cached files'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;cache;help;list'= {
+        }
+        &'stackablectl;cache;help;clean'= {
+        }
+        &'stackablectl;cache;help;help'= {
+        }
+        &'stackablectl;experimental-debug'= {
+            cand -n 'The namespace of the Pod being debugged'
+            cand --namespace 'The namespace of the Pod being debugged'
+            cand -c 'The target container to debug'
+            cand --container 'The target container to debug'
+            cand --image 'The debug container image'
+            cand -l 'Log level this application uses'
+            cand --log-level 'Log level this application uses'
+            cand -d 'Provide one or more additional (custom) demo file(s)'
+            cand --demo-file 'Provide one or more additional (custom) demo file(s)'
+            cand -s 'Provide one or more additional (custom) stack file(s)'
+            cand --stack-file 'Provide one or more additional (custom) stack file(s)'
+            cand -r 'Provide one or more additional (custom) release file(s)'
+            cand --release-file 'Provide one or more additional (custom) release file(s)'
+            cand --helm-repo-stable 'Provide a custom Helm stable repository URL'
+            cand --helm-repo-test 'Provide a custom Helm test repository URL'
+            cand --helm-repo-dev 'Provide a custom Helm dev repository URL'
+            cand --no-cache 'Do not cache the remote (default) demo, stack and release files'
+            cand --offline 'Do not request any remote files via the network'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'stackablectl;help'= {
+            cand operator 'Interact with single operator instead of the full platform'
+            cand release 'Interact with all operators of the platform which are released together'
+            cand stack 'Interact with stacks, which are ready-to-use product combinations'
+            cand stacklet 'Interact with deployed stacklets, which are bundles of resources and containers required to run the product'
+            cand demo 'Interact with demos, which are end-to-end usage demonstrations of the Stackable data platform'
+            cand completions 'Generate shell completions for this tool'
+            cand cache 'Interact with locally cached files'
+            cand experimental-debug 'EXPERIMENTAL: Launch a debug container for a Pod'
+            cand help 'Print this message or the help of the given subcommand(s)'
+        }
+        &'stackablectl;help;operator'= {
+            cand list 'List available operators'
+            cand describe 'Print out detailed operator information'
+            cand install 'Install one or more operators'
+            cand uninstall 'Uninstall one or more operators'
+            cand installed 'List installed operators'
+        }
+        &'stackablectl;help;operator;list'= {
+        }
+        &'stackablectl;help;operator;describe'= {
+        }
+        &'stackablectl;help;operator;install'= {
+        }
+        &'stackablectl;help;operator;uninstall'= {
+        }
+        &'stackablectl;help;operator;installed'= {
+        }
+        &'stackablectl;help;release'= {
+            cand list 'List available releases'
+            cand describe 'Print out detailed release information'
+            cand install 'Install a specific release'
+            cand uninstall 'Uninstall a release'
+        }
+        &'stackablectl;help;release;list'= {
+        }
+        &'stackablectl;help;release;describe'= {
+        }
+        &'stackablectl;help;release;install'= {
+        }
+        &'stackablectl;help;release;uninstall'= {
+        }
+        &'stackablectl;help;stack'= {
+            cand list 'List available stacks'
+            cand describe 'Describe a specific stack'
+            cand install 'Install a specific stack'
+        }
+        &'stackablectl;help;stack;list'= {
+        }
+        &'stackablectl;help;stack;describe'= {
+        }
+        &'stackablectl;help;stack;install'= {
+        }
+        &'stackablectl;help;stacklet'= {
+            cand credentials 'Display credentials for a stacklet'
+            cand list 'List deployed stacklets'
+        }
+        &'stackablectl;help;stacklet;credentials'= {
+        }
+        &'stackablectl;help;stacklet;list'= {
+        }
+        &'stackablectl;help;demo'= {
+            cand list 'List available demos'
+            cand describe 'Print out detailed demo information'
+            cand install 'Install a specific demo'
+        }
+        &'stackablectl;help;demo;list'= {
+        }
+        &'stackablectl;help;demo;describe'= {
+        }
+        &'stackablectl;help;demo;install'= {
+        }
+        &'stackablectl;help;completions'= {
+            cand bash 'Generate shell completions for Bash'
+            cand elvish 'Generate shell completions for Elvish'
+            cand fish 'Generate shell completions for Fish'
+            cand nushell 'Generate shell completions for Nushell'
+            cand zsh 'Generate shell completions for ZSH'
+        }
+        &'stackablectl;help;completions;bash'= {
+        }
+        &'stackablectl;help;completions;elvish'= {
+        }
+        &'stackablectl;help;completions;fish'= {
+        }
+        &'stackablectl;help;completions;nushell'= {
+        }
+        &'stackablectl;help;completions;zsh'= {
+        }
+        &'stackablectl;help;cache'= {
+            cand list 'List cached files'
+            cand clean 'Clean cached files'
+        }
+        &'stackablectl;help;cache;list'= {
+        }
+        &'stackablectl;help;cache;clean'= {
+        }
+        &'stackablectl;help;experimental-debug'= {
+        }
+        &'stackablectl;help;help'= {
+        }
+    ]
+    $completions[$command]
+}

--- a/extra/completions/stackablectl.fish
+++ b/extra/completions/stackablectl.fish
@@ -376,22 +376,23 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fi
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fish_seen_subcommand_from help" -f -a "describe" -d 'Print out detailed demo information'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fish_seen_subcommand_from help" -f -a "install" -d 'Install a specific demo'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s l -l log-level -d 'Log level this application uses' -r
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s r -l release-file -d 'Provide one or more additional (custom) release file(s)' -r -F
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l helm-repo-stable -d 'Provide a custom Helm stable repository URL' -r -f
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l helm-repo-test -d 'Provide a custom Helm test repository URL' -r -f
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l helm-repo-dev -d 'Provide a custom Helm dev repository URL' -r -f
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l no-cache -d 'Do not cache the remote (default) demo, stack and release files'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l offline -d 'Do not request any remote files via the network'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s V -l version -d 'Print version'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "bash" -d 'Generate shell completions for Bash'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "fish" -d 'Generate shell completions for Fish'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "nushell" -d 'Generate shell completions for Nushell'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "zsh" -d 'Generate shell completions for ZSH'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -s l -l log-level -d 'Log level this application uses' -r
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -s r -l release-file -d 'Provide one or more additional (custom) release file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -l helm-repo-stable -d 'Provide a custom Helm stable repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -l helm-repo-test -d 'Provide a custom Helm test repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -l helm-repo-dev -d 'Provide a custom Helm dev repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -l no-cache -d 'Do not cache the remote (default) demo, stack and release files'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -l offline -d 'Do not request any remote files via the network'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -s V -l version -d 'Print version'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -f -a "bash" -d 'Generate shell completions for Bash'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -f -a "elvish" -d 'Generate shell completions for Elvish'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -f -a "fish" -d 'Generate shell completions for Fish'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -f -a "nushell" -d 'Generate shell completions for Nushell'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -f -a "zsh" -d 'Generate shell completions for ZSH'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash elvish fish nushell zsh help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s l -l log-level -d 'Log level this application uses' -r
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
@@ -403,6 +404,17 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; a
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -l offline -d 'Do not request any remote files via the network'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s V -l version -d 'Print version'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -s l -l log-level -d 'Log level this application uses' -r
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -s r -l release-file -d 'Provide one or more additional (custom) release file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -l helm-repo-stable -d 'Provide a custom Helm stable repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -l helm-repo-test -d 'Provide a custom Helm test repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -l helm-repo-dev -d 'Provide a custom Helm dev repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -l no-cache -d 'Do not cache the remote (default) demo, stack and release files'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -l offline -d 'Do not request any remote files via the network'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from elvish" -s V -l version -d 'Print version'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from fish" -s l -l log-level -d 'Log level this application uses' -r
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from fish" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from fish" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
@@ -437,6 +449,7 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; a
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from zsh" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from zsh" -s V -l version -d 'Print version'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "bash" -d 'Generate shell completions for Bash'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "elvish" -d 'Generate shell completions for Elvish'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "fish" -d 'Generate shell completions for Fish'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "nushell" -d 'Generate shell completions for Nushell'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "zsh" -d 'Generate shell completions for ZSH'
@@ -522,6 +535,7 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fi
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from demo" -f -a "describe" -d 'Print out detailed demo information'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from demo" -f -a "install" -d 'Install a specific demo'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "bash" -d 'Generate shell completions for Bash'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "elvish" -d 'Generate shell completions for Elvish'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "fish" -d 'Generate shell completions for Fish'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "nushell" -d 'Generate shell completions for Nushell'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "zsh" -d 'Generate shell completions for ZSH'

--- a/extra/completions/stackablectl.fish
+++ b/extra/completions/stackablectl.fish
@@ -376,21 +376,22 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fi
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fish_seen_subcommand_from help" -f -a "describe" -d 'Print out detailed demo information'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fish_seen_subcommand_from help" -f -a "install" -d 'Install a specific demo'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand demo; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -s l -l log-level -d 'Log level this application uses' -r
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -s r -l release-file -d 'Provide one or more additional (custom) release file(s)' -r -F
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -l helm-repo-stable -d 'Provide a custom Helm stable repository URL' -r -f
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -l helm-repo-test -d 'Provide a custom Helm test repository URL' -r -f
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -l helm-repo-dev -d 'Provide a custom Helm dev repository URL' -r -f
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -l no-cache -d 'Do not cache the remote (default) demo, stack and release files'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -l offline -d 'Do not request any remote files via the network'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -s V -l version -d 'Print version'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -f -a "bash" -d 'Generate shell completions for Bash'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -f -a "fish" -d 'Generate shell completions for Fish'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -f -a "zsh" -d 'Generate shell completions for ZSH'
-complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish zsh help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s l -l log-level -d 'Log level this application uses' -r
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s r -l release-file -d 'Provide one or more additional (custom) release file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l helm-repo-stable -d 'Provide a custom Helm stable repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l helm-repo-test -d 'Provide a custom Helm test repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l helm-repo-dev -d 'Provide a custom Helm dev repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l no-cache -d 'Do not cache the remote (default) demo, stack and release files'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -l offline -d 'Do not request any remote files via the network'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -s V -l version -d 'Print version'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "bash" -d 'Generate shell completions for Bash'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "fish" -d 'Generate shell completions for Fish'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "nushell" -d 'Generate shell completions for Nushell'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "zsh" -d 'Generate shell completions for ZSH'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and not __fish_seen_subcommand_from bash fish nushell zsh help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s l -l log-level -d 'Log level this application uses' -r
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from bash" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
@@ -413,6 +414,17 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; a
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from fish" -l offline -d 'Do not request any remote files via the network'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from fish" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from fish" -s V -l version -d 'Print version'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -s l -l log-level -d 'Log level this application uses' -r
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -s r -l release-file -d 'Provide one or more additional (custom) release file(s)' -r -F
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -l helm-repo-stable -d 'Provide a custom Helm stable repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -l helm-repo-test -d 'Provide a custom Helm test repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -l helm-repo-dev -d 'Provide a custom Helm dev repository URL' -r -f
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -l no-cache -d 'Do not cache the remote (default) demo, stack and release files'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -l offline -d 'Do not request any remote files via the network'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from nushell" -s V -l version -d 'Print version'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from zsh" -s l -l log-level -d 'Log level this application uses' -r
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from zsh" -s d -l demo-file -d 'Provide one or more additional (custom) demo file(s)' -r -F
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from zsh" -s s -l stack-file -d 'Provide one or more additional (custom) stack file(s)' -r -F
@@ -426,6 +438,7 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; a
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from zsh" -s V -l version -d 'Print version'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "bash" -d 'Generate shell completions for Bash'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "fish" -d 'Generate shell completions for Fish'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "nushell" -d 'Generate shell completions for Nushell'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "zsh" -d 'Generate shell completions for ZSH'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand completions; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand cache; and not __fish_seen_subcommand_from list clean help" -s l -l log-level -d 'Log level this application uses' -r
@@ -510,6 +523,7 @@ complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fi
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from demo" -f -a "install" -d 'Install a specific demo'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "bash" -d 'Generate shell completions for Bash'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "fish" -d 'Generate shell completions for Fish'
+complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "nushell" -d 'Generate shell completions for Nushell'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from completions" -f -a "zsh" -d 'Generate shell completions for ZSH'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from cache" -f -a "list" -d 'List cached files'
 complete -c stackablectl -n "__fish_stackablectl_using_subcommand help; and __fish_seen_subcommand_from cache" -f -a "clean" -d 'Clean cached files'

--- a/extra/completions/stackablectl.nu
+++ b/extra/completions/stackablectl.nu
@@ -609,6 +609,21 @@ module completions {
     --version(-V)             # Print version
   ]
 
+  # Generate shell completions for Elvish
+  export extern "stackablectl completions elvish" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
   # Generate shell completions for Fish
   export extern "stackablectl completions fish" [
     --log-level(-l): string   # Log level this application uses
@@ -660,6 +675,10 @@ module completions {
 
   # Generate shell completions for Bash
   export extern "stackablectl completions help bash" [
+  ]
+
+  # Generate shell completions for Elvish
+  export extern "stackablectl completions help elvish" [
   ]
 
   # Generate shell completions for Fish
@@ -859,6 +878,10 @@ module completions {
 
   # Generate shell completions for Bash
   export extern "stackablectl help completions bash" [
+  ]
+
+  # Generate shell completions for Elvish
+  export extern "stackablectl help completions elvish" [
   ]
 
   # Generate shell completions for Fish

--- a/extra/completions/stackablectl.nu
+++ b/extra/completions/stackablectl.nu
@@ -1,0 +1,898 @@
+module completions {
+
+  # Command line tool to interact with the Stackable Data Platform
+  export extern stackablectl [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Interact with single operator instead of the full platform
+  export extern "stackablectl operator" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl operator list output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # List available operators
+  export extern "stackablectl operator list" [
+    --output(-o): string@"nu-complete stackablectl operator list output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl operator describe output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # Print out detailed operator information
+  export extern "stackablectl operator describe" [
+    OPERATOR: string          # Operator to describe
+    --output(-o): string@"nu-complete stackablectl operator describe output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl operator install cluster_type" [] {
+    [ "kind" "minikube" ]
+  }
+
+  # Install one or more operators
+  export extern "stackablectl operator install" [
+    ...OPERATORS: string      # Operator(s) to install
+    --operator-namespace: string # Namespace in the cluster used to deploy the operators
+    --operator-ns: string     # Namespace in the cluster used to deploy the operators
+    --cluster(-c): string@"nu-complete stackablectl operator install cluster_type" # Type of local cluster to use for testing
+    --cluster-name: string    # Name of the local cluster
+    --cluster-nodes: string   # Number of total nodes in the local cluster
+    --cluster-cp-nodes: string # Number of control plane nodes in the local cluster
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Uninstall one or more operators
+  export extern "stackablectl operator uninstall" [
+    ...operators: string      # One or more operators to uninstall
+    --operator-namespace: string # Namespace in the cluster used to deploy the operators
+    --operator-ns: string     # Namespace in the cluster used to deploy the operators
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl operator installed output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # List installed operators
+  export extern "stackablectl operator installed" [
+    --output(-o): string@"nu-complete stackablectl operator installed output_type"
+    --operator-namespace: string # Namespace in the cluster used to deploy the operators
+    --operator-ns: string     # Namespace in the cluster used to deploy the operators
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl operator help" [
+  ]
+
+  # List available operators
+  export extern "stackablectl operator help list" [
+  ]
+
+  # Print out detailed operator information
+  export extern "stackablectl operator help describe" [
+  ]
+
+  # Install one or more operators
+  export extern "stackablectl operator help install" [
+  ]
+
+  # Uninstall one or more operators
+  export extern "stackablectl operator help uninstall" [
+  ]
+
+  # List installed operators
+  export extern "stackablectl operator help installed" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl operator help help" [
+  ]
+
+  # Interact with all operators of the platform which are released together
+  export extern "stackablectl release" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl release list output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # List available releases
+  export extern "stackablectl release list" [
+    --output(-o): string@"nu-complete stackablectl release list output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl release describe output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # Print out detailed release information
+  export extern "stackablectl release describe" [
+    RELEASE: string
+    --output(-o): string@"nu-complete stackablectl release describe output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl release install cluster_type" [] {
+    [ "kind" "minikube" ]
+  }
+
+  # Install a specific release
+  export extern "stackablectl release install" [
+    RELEASE: string           # Release to install
+    --include(-i): string     # Whitelist of product operators to install
+    --exclude(-e): string     # Blacklist of product operators to install
+    --operator-namespace: string # Namespace in the cluster used to deploy the operators
+    --operator-ns: string     # Namespace in the cluster used to deploy the operators
+    --cluster(-c): string@"nu-complete stackablectl release install cluster_type" # Type of local cluster to use for testing
+    --cluster-name: string    # Name of the local cluster
+    --cluster-nodes: string   # Number of total nodes in the local cluster
+    --cluster-cp-nodes: string # Number of control plane nodes in the local cluster
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Uninstall a release
+  export extern "stackablectl release uninstall" [
+    RELEASE: string           # Name of the release to uninstall
+    --operator-namespace: string # Namespace in the cluster used to deploy the operators
+    --operator-ns: string     # Namespace in the cluster used to deploy the operators
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl release help" [
+  ]
+
+  # List available releases
+  export extern "stackablectl release help list" [
+  ]
+
+  # Print out detailed release information
+  export extern "stackablectl release help describe" [
+  ]
+
+  # Install a specific release
+  export extern "stackablectl release help install" [
+  ]
+
+  # Uninstall a release
+  export extern "stackablectl release help uninstall" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl release help help" [
+  ]
+
+  # Interact with stacks, which are ready-to-use product combinations
+  export extern "stackablectl stack" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl stack list output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # List available stacks
+  export extern "stackablectl stack list" [
+    --output(-o): string@"nu-complete stackablectl stack list output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl stack describe output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # Describe a specific stack
+  export extern "stackablectl stack describe" [
+    stack_name: string        # Name of the stack to describe
+    --output(-o): string@"nu-complete stackablectl stack describe output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl stack install cluster_type" [] {
+    [ "kind" "minikube" ]
+  }
+
+  # Install a specific stack
+  export extern "stackablectl stack install" [
+    stack_name: string        # Name of the stack to describe
+    --skip-release            # Skip the installation of the release during the stack install process
+    --stack-parameters: string # List of parameters to use when installing the stack
+    --parameters: string      # List of parameters to use when installing the stack
+    --cluster(-c): string@"nu-complete stackablectl stack install cluster_type" # Type of local cluster to use for testing
+    --cluster-name: string    # Name of the local cluster
+    --cluster-nodes: string   # Number of total nodes in the local cluster
+    --cluster-cp-nodes: string # Number of control plane nodes in the local cluster
+    --operator-namespace: string # Namespace where the operators are deployed
+    --operator-ns: string     # Namespace where the operators are deployed
+    --product-namespace(-n): string # Namespace where the products (e.g. stacks or demos) are deployed
+    --product-ns: string      # Namespace where the products (e.g. stacks or demos) are deployed
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl stack help" [
+  ]
+
+  # List available stacks
+  export extern "stackablectl stack help list" [
+  ]
+
+  # Describe a specific stack
+  export extern "stackablectl stack help describe" [
+  ]
+
+  # Install a specific stack
+  export extern "stackablectl stack help install" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl stack help help" [
+  ]
+
+  # Interact with deployed stacklets, which are bundles of resources and containers required to run the product
+  export extern "stackablectl stacklet" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Display credentials for a stacklet
+  export extern "stackablectl stacklet credentials" [
+    product_name: string      # The name of the product, for example 'superset'
+    stacklet_name: string     # The name of the stacklet, for example 'superset'
+    --product-namespace(-n): string # Namespace in the cluster used to deploy the products
+    --product-ns: string      # Namespace in the cluster used to deploy the products
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl stacklet list output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # List deployed stacklets
+  export extern "stackablectl stacklet list" [
+    --output(-o): string@"nu-complete stackablectl stacklet list output_type"
+    --operator-namespace: string # Namespace where the operators are deployed
+    --operator-ns: string     # Namespace where the operators are deployed
+    --product-namespace(-n): string # Namespace where the products (e.g. stacks or demos) are deployed
+    --product-ns: string      # Namespace where the products (e.g. stacks or demos) are deployed
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl stacklet help" [
+  ]
+
+  # Display credentials for a stacklet
+  export extern "stackablectl stacklet help credentials" [
+  ]
+
+  # List deployed stacklets
+  export extern "stackablectl stacklet help list" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl stacklet help help" [
+  ]
+
+  # Interact with demos, which are end-to-end usage demonstrations of the Stackable data platform
+  export extern "stackablectl demo" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl demo list output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # List available demos
+  export extern "stackablectl demo list" [
+    --output(-o): string@"nu-complete stackablectl demo list output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl demo describe output_type" [] {
+    [ "plain" "table" "json" "yaml" ]
+  }
+
+  # Print out detailed demo information
+  export extern "stackablectl demo describe" [
+    DEMO: string              # Demo to describe
+    --output(-o): string@"nu-complete stackablectl demo describe output_type"
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  def "nu-complete stackablectl demo install cluster_type" [] {
+    [ "kind" "minikube" ]
+  }
+
+  # Install a specific demo
+  export extern "stackablectl demo install" [
+    DEMO: string              # Demo to install
+    --skip-release            # Skip the installation of the release during the stack install process
+    --stack-parameters: string # List of parameters to use when installing the stack
+    --parameters: string      # List of parameters to use when installing the demo
+    --cluster(-c): string@"nu-complete stackablectl demo install cluster_type" # Type of local cluster to use for testing
+    --cluster-name: string    # Name of the local cluster
+    --cluster-nodes: string   # Number of total nodes in the local cluster
+    --cluster-cp-nodes: string # Number of control plane nodes in the local cluster
+    --operator-namespace: string # Namespace where the operators are deployed
+    --operator-ns: string     # Namespace where the operators are deployed
+    --product-namespace(-n): string # Namespace where the products (e.g. stacks or demos) are deployed
+    --product-ns: string      # Namespace where the products (e.g. stacks or demos) are deployed
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl demo help" [
+  ]
+
+  # List available demos
+  export extern "stackablectl demo help list" [
+  ]
+
+  # Print out detailed demo information
+  export extern "stackablectl demo help describe" [
+  ]
+
+  # Install a specific demo
+  export extern "stackablectl demo help install" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl demo help help" [
+  ]
+
+  # Generate shell completions for this tool
+  export extern "stackablectl completions" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Generate shell completions for Bash
+  export extern "stackablectl completions bash" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Generate shell completions for Fish
+  export extern "stackablectl completions fish" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Generate shell completions for Nushell
+  export extern "stackablectl completions nushell" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Generate shell completions for ZSH
+  export extern "stackablectl completions zsh" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl completions help" [
+  ]
+
+  # Generate shell completions for Bash
+  export extern "stackablectl completions help bash" [
+  ]
+
+  # Generate shell completions for Fish
+  export extern "stackablectl completions help fish" [
+  ]
+
+  # Generate shell completions for Nushell
+  export extern "stackablectl completions help nushell" [
+  ]
+
+  # Generate shell completions for ZSH
+  export extern "stackablectl completions help zsh" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl completions help help" [
+  ]
+
+  # Interact with locally cached files
+  export extern "stackablectl cache" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # List cached files
+  export extern "stackablectl cache list" [
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Clean cached files
+  export extern "stackablectl cache clean" [
+    --old                     # Only remove outdated files in the cache
+    --outdated                # Only remove outdated files in the cache
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl cache help" [
+  ]
+
+  # List cached files
+  export extern "stackablectl cache help list" [
+  ]
+
+  # Clean cached files
+  export extern "stackablectl cache help clean" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl cache help help" [
+  ]
+
+  # EXPERIMENTAL: Launch a debug container for a Pod
+  export extern "stackablectl experimental-debug" [
+    --namespace(-n): string   # The namespace of the Pod being debugged
+    pod: string               # The Pod to debug
+    --container(-c): string   # The target container to debug
+    --image: string           # The debug container image
+    ...cmd: string            # The command to run in the debug container
+    --log-level(-l): string   # Log level this application uses
+    --no-cache                # Do not cache the remote (default) demo, stack and release files
+    --offline                 # Do not request any remote files via the network
+    --demo-file(-d): string   # Provide one or more additional (custom) demo file(s)
+    --stack-file(-s): string  # Provide one or more additional (custom) stack file(s)
+    --release-file(-r): string # Provide one or more additional (custom) release file(s)
+    --helm-repo-stable: string # Provide a custom Helm stable repository URL
+    --helm-repo-test: string  # Provide a custom Helm test repository URL
+    --helm-repo-dev: string   # Provide a custom Helm dev repository URL
+    --help(-h)                # Print help (see more with '--help')
+    --version(-V)             # Print version
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl help" [
+  ]
+
+  # Interact with single operator instead of the full platform
+  export extern "stackablectl help operator" [
+  ]
+
+  # List available operators
+  export extern "stackablectl help operator list" [
+  ]
+
+  # Print out detailed operator information
+  export extern "stackablectl help operator describe" [
+  ]
+
+  # Install one or more operators
+  export extern "stackablectl help operator install" [
+  ]
+
+  # Uninstall one or more operators
+  export extern "stackablectl help operator uninstall" [
+  ]
+
+  # List installed operators
+  export extern "stackablectl help operator installed" [
+  ]
+
+  # Interact with all operators of the platform which are released together
+  export extern "stackablectl help release" [
+  ]
+
+  # List available releases
+  export extern "stackablectl help release list" [
+  ]
+
+  # Print out detailed release information
+  export extern "stackablectl help release describe" [
+  ]
+
+  # Install a specific release
+  export extern "stackablectl help release install" [
+  ]
+
+  # Uninstall a release
+  export extern "stackablectl help release uninstall" [
+  ]
+
+  # Interact with stacks, which are ready-to-use product combinations
+  export extern "stackablectl help stack" [
+  ]
+
+  # List available stacks
+  export extern "stackablectl help stack list" [
+  ]
+
+  # Describe a specific stack
+  export extern "stackablectl help stack describe" [
+  ]
+
+  # Install a specific stack
+  export extern "stackablectl help stack install" [
+  ]
+
+  # Interact with deployed stacklets, which are bundles of resources and containers required to run the product
+  export extern "stackablectl help stacklet" [
+  ]
+
+  # Display credentials for a stacklet
+  export extern "stackablectl help stacklet credentials" [
+  ]
+
+  # List deployed stacklets
+  export extern "stackablectl help stacklet list" [
+  ]
+
+  # Interact with demos, which are end-to-end usage demonstrations of the Stackable data platform
+  export extern "stackablectl help demo" [
+  ]
+
+  # List available demos
+  export extern "stackablectl help demo list" [
+  ]
+
+  # Print out detailed demo information
+  export extern "stackablectl help demo describe" [
+  ]
+
+  # Install a specific demo
+  export extern "stackablectl help demo install" [
+  ]
+
+  # Generate shell completions for this tool
+  export extern "stackablectl help completions" [
+  ]
+
+  # Generate shell completions for Bash
+  export extern "stackablectl help completions bash" [
+  ]
+
+  # Generate shell completions for Fish
+  export extern "stackablectl help completions fish" [
+  ]
+
+  # Generate shell completions for Nushell
+  export extern "stackablectl help completions nushell" [
+  ]
+
+  # Generate shell completions for ZSH
+  export extern "stackablectl help completions zsh" [
+  ]
+
+  # Interact with locally cached files
+  export extern "stackablectl help cache" [
+  ]
+
+  # List cached files
+  export extern "stackablectl help cache list" [
+  ]
+
+  # Clean cached files
+  export extern "stackablectl help cache clean" [
+  ]
+
+  # EXPERIMENTAL: Launch a debug container for a Pod
+  export extern "stackablectl help experimental-debug" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "stackablectl help help" [
+  ]
+
+}
+
+export use completions *

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Shell completions for Nushell and Elvish ([#337]).
+- Add shell completions for Nushell and Elvish ([#337]).
 
 [#337]: https://github.com/stackabletech/stackable-cockpit/pull/337
 

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Shell completions for Nushell and Elvish ([#337]).
+
+[#337]: https://github.com/stackabletech/stackable-cockpit/pull/337
+
 ## [24.11.0] - 2024-11-18
 
 ### Changed

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -14,6 +14,7 @@ stackable-cockpit = { path = "../stackable-cockpit", features = ["openapi"] }
 stackable-operator.workspace = true
 
 clap_complete.workspace = true
+clap_complete_nushell.workspace = true
 clap.workspace = true
 comfy-table.workspace = true
 directories.workspace = true

--- a/rust/stackablectl/src/cmds/completions.rs
+++ b/rust/stackablectl/src/cmds/completions.rs
@@ -1,7 +1,7 @@
 use clap::{Args, CommandFactory, Subcommand};
 use clap_complete::{
     generate, Generator,
-    Shell::{Bash, Fish, Zsh},
+    Shell::{Bash, Elvish, Fish, Zsh},
 };
 use clap_complete_nushell::Nushell;
 use snafu::{ResultExt, Snafu};
@@ -18,6 +18,9 @@ pub struct CompletionsArgs {
 pub enum CompletionCommands {
     /// Generate shell completions for Bash
     Bash,
+
+    /// Generate shell completions for Elvish
+    Elvish,
 
     /// Generate shell completions for Fish
     Fish,
@@ -40,6 +43,7 @@ impl CompletionsArgs {
         match &self.subcommand {
             CompletionCommands::Bash => generate_completions(Bash),
             CompletionCommands::Fish => generate_completions(Fish),
+            CompletionCommands::Elvish => generate_completions(Elvish),
             CompletionCommands::Nushell => generate_completions(Nushell),
             CompletionCommands::Zsh => generate_completions(Zsh),
         }

--- a/rust/stackablectl/src/cmds/completions.rs
+++ b/rust/stackablectl/src/cmds/completions.rs
@@ -1,5 +1,9 @@
 use clap::{Args, CommandFactory, Subcommand};
-use clap_complete::{generate, Shell};
+use clap_complete::{
+    generate, Generator,
+    Shell::{Bash, Fish, Zsh},
+};
+use clap_complete_nushell::Nushell;
 use snafu::{ResultExt, Snafu};
 
 use crate::cli::Cli;
@@ -18,6 +22,9 @@ pub enum CompletionCommands {
     /// Generate shell completions for Fish
     Fish,
 
+    /// Generate shell completions for Nushell
+    Nushell,
+
     /// Generate shell completions for ZSH
     Zsh,
 }
@@ -31,14 +38,18 @@ pub enum CmdError {
 impl CompletionsArgs {
     pub fn run(&self) -> Result<String, CmdError> {
         match &self.subcommand {
-            CompletionCommands::Bash => generate_completions(Shell::Bash),
-            CompletionCommands::Fish => generate_completions(Shell::Fish),
-            CompletionCommands::Zsh => generate_completions(Shell::Zsh),
+            CompletionCommands::Bash => generate_completions(Bash),
+            CompletionCommands::Fish => generate_completions(Fish),
+            CompletionCommands::Nushell => generate_completions(Nushell),
+            CompletionCommands::Zsh => generate_completions(Zsh),
         }
     }
 }
 
-fn generate_completions(shell: Shell) -> Result<String, CmdError> {
+fn generate_completions<G>(shell: G) -> Result<String, CmdError>
+where
+    G: Generator,
+{
     let mut cmd = Cli::command();
     let mut buf = Vec::new();
 

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-clap_complete = { workspace = true }
+clap_complete.workspace = true
+clap_complete_nushell.workspace = true
 clap_mangen = "0.2.10"
 clap.workspace = true
 once_cell.workspace = true

--- a/rust/xtask/src/completions.rs
+++ b/rust/xtask/src/completions.rs
@@ -3,7 +3,7 @@ use std::fs;
 use clap::CommandFactory;
 use clap_complete::{
     generate as generate_comps,
-    Shell::{Bash, Fish, Zsh},
+    Shell::{Bash, Elvish, Fish, Zsh},
 };
 use clap_complete_nushell::Nushell;
 use snafu::{ResultExt, Snafu};
@@ -24,6 +24,10 @@ pub fn generate() -> Result<(), GenCompError> {
     // Bash completions
     let mut f = fs::File::create("extra/completions/stackablectl.bash").context(IoSnafu)?;
     generate_comps(Bash, &mut cmd, name.clone(), &mut f);
+
+    // Elvish completions
+    let mut f = fs::File::create("extra/completions/stackablectl.elv").context(IoSnafu)?;
+    generate_comps(Elvish, &mut cmd, name.clone(), &mut f);
 
     // Fish completions
     let mut f = fs::File::create("extra/completions/stackablectl.fish").context(IoSnafu)?;

--- a/rust/xtask/src/completions.rs
+++ b/rust/xtask/src/completions.rs
@@ -1,7 +1,11 @@
 use std::fs;
 
 use clap::CommandFactory;
-use clap_complete::{generate as generate_comps, Shell};
+use clap_complete::{
+    generate as generate_comps,
+    Shell::{Bash, Fish, Zsh},
+};
+use clap_complete_nushell::Nushell;
 use snafu::{ResultExt, Snafu};
 use stackablectl::cli::Cli;
 
@@ -19,15 +23,19 @@ pub fn generate() -> Result<(), GenCompError> {
 
     // Bash completions
     let mut f = fs::File::create("extra/completions/stackablectl.bash").context(IoSnafu)?;
-    generate_comps(Shell::Bash, &mut cmd, name.clone(), &mut f);
+    generate_comps(Bash, &mut cmd, name.clone(), &mut f);
 
     // Fish completions
     let mut f = fs::File::create("extra/completions/stackablectl.fish").context(IoSnafu)?;
-    generate_comps(Shell::Fish, &mut cmd, name.clone(), &mut f);
+    generate_comps(Fish, &mut cmd, name.clone(), &mut f);
+
+    // Nushell completions
+    let mut f = fs::File::create("extra/completions/stackablectl.nu").context(IoSnafu)?;
+    generate_comps(Nushell, &mut cmd, name.clone(), &mut f);
 
     // ZSH completions
     let mut f = fs::File::create("extra/completions/_stackablectl").context(IoSnafu)?;
-    generate_comps(Shell::Zsh, &mut cmd, name, &mut f);
+    generate_comps(Zsh, &mut cmd, name, &mut f);
 
     Ok(())
 }

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -15,6 +15,7 @@ mod readme;
 #[derive(clap::Parser)]
 #[allow(clippy::enum_variant_names)]
 enum XtaskCommand {
+    GenAll,
     GenMan,
     GenComp,
     GenOpenapi,
@@ -49,6 +50,14 @@ enum TaskError {
 #[snafu::report]
 fn main() -> Result<(), TaskError> {
     match XtaskCommand::parse() {
+        XtaskCommand::GenAll => {
+            // IMPORTANT (@NickLarsenNZ): ensure all commands defined below are also in here.
+            man::generate()?;
+            completions::generate()?;
+            openapi::generate()?;
+            readme::generate()?;
+            docs::generate()?;
+        }
         XtaskCommand::GenMan => man::generate()?,
         XtaskCommand::GenComp => completions::generate()?,
         XtaskCommand::GenOpenapi => openapi::generate()?,


### PR DESCRIPTION
# Description

- Nushell completions.
  _Uses the [clap_complete_nushell] crate, as linked by the already used [clap_complete] crate._
- Elvish completions.
  _Already included in [clap_complete], so why not?_ 
- Update xtasks to generate the new shell completions.
- New xtask command to run all xtasks (useful for local development).
- Disable shellcheck on generated completions.

[clap_complete_nushell]: https://crates.io/crates/clap_complete_nushell
[clap_complete]: https://crates.io/crates/clap_complete