### PR TITLE
chore: Release stackablectl-24.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.11.0"
+version = "24.11.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9959,7 +9959,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.11.0";
+        version = "24.11.1";
         edition = "2021";
         crateBin = [
           {

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.11.0" 
+.TH stackablectl 1  "stackablectl 24.11.1" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -98,6 +98,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.11.0
+v24.11.1
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.11.1] - 2024-11-20
+
 ### Added
 
 - Add shell completions for Nushell and Elvish ([#337]).

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.11.0"
+version = "24.11.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release includes:

### Added

- Add shell completions for Nushell and Elvish ([#337]).
- SOCKS5 and HTTP proxy support ([#328]).

### Fixed

- Sort operator versions by semver version instead of alphabetically ([#336]).

[#328]: https://github.com/stackabletech/stackable-cockpit/pull/328
[#336]: https://github.com/stackabletech/stackable-cockpit/pull/336
[#337]: https://github.com/stackabletech/stackable-cockpit/pull/337