### PR TITLE
chore: Release stackablectl-24.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.11.1"
+version = "24.11.2"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -10057,7 +10057,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.11.1";
+        version = "24.11.2";
         edition = "2021";
         crateBin = [
           {

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.11.1" 
+.TH stackablectl 1  "stackablectl 24.11.2" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -95,6 +95,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.11.1
+v24.11.2
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.11.2] - 2025-01-15
+
 ### Added
 
 - Add new argument `--release` that allows installing a specific version of a demo or stack ([#340]).

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.11.1"
+version = "24.11.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases `stackablectl-24.11.2` which includes:

### Added

- Add new argument `--release` that allows installing a specific version of a demo or stack ([#340]).

### Removed

- Remove argument `--offline` that was not implemented yet ([#340]).

[#340]: https://github.com/stackabletech/stackable-cockpit/pull/340