### PR TITLE
Move from BuildJet to GitHub ARM runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,0 @@
----
-self-hosted-runner:
-  # BuildJet machines we are using
-  labels:
-    - buildjet-2vcpu-ubuntu-2204-arm
-    - buildjet-4vcpu-ubuntu-2204-arm

--- a/.github/workflows/pr_stackablectl.yml
+++ b/.github/workflows/pr_stackablectl.yml
@@ -40,7 +40,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: buildjet-4vcpu-ubuntu-2204-arm
+            os: ubuntu-22.04-arm
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin

--- a/.github/workflows/release_stackablectl.yml
+++ b/.github/workflows/release_stackablectl.yml
@@ -27,7 +27,7 @@ jobs:
             os: ubuntu-20.04 # We don't use ubuntu-latest because we want to build against an old glibc version. (18.04 has glibc 2.27, 20.04 has glibc 2.31, 22.04 has glibc 2.35)
             file-suffix: ""
           - target: aarch64-unknown-linux-gnu
-            os: buildjet-4vcpu-ubuntu-2204-arm # The ARM runners only support Ubuntu 22.04, so we can't pick 20.04
+            os: ubuntu-22.04-arm # 2025-01: The ARM runners only support Ubuntu 22.04 or 24.04, so we can't pick 20.04:
             file-suffix: ""
           - target: x86_64-apple-darwin
             os: macos-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         exclude: '^extra/completions/'
 
   - repo: https://github.com/rhysd/actionlint
-    rev: 62dc61a45fc95efe8c800af7a557ab0b9165d63b # 1.7.1
+    rev: 03d0035246f3e81f36aed592ffb4bebf33a03106 # 1.7.7
     hooks:
       - id: actionlint
 


### PR DESCRIPTION
# Description

This is our last repository still using BuildJet.
This PR tries to move to the new GitHub runners but we can also move to Ubicloud if needed

## Definition of Done Checklist


```[tasklist]
# Reviewer
- [ ] Changelog updated
```
