### PR TITLE
chore: Release stackablectl-24.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.11.2"
+version = "24.11.3"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -10061,7 +10061,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.11.2";
+        version = "24.11.3";
         edition = "2021";
         crateBin = [
           {

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.11.2" 
+.TH stackablectl 1  "stackablectl 24.11.3" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -108,6 +108,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.11.2
+v24.11.3
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [24.11.3] - 2025-01-27
+
 ### Added
 
 - Add new argument `--chart-source` so that operator charts can be pulled either from an OCI registry (the default) or from a index.yaml-based repository ([#344]).

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.11.2"
+version = "24.11.3"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR releases stackablectl-24.11.3 which includes:

### Added

- Add new argument `--chart-source` so that operator charts can be pulled either from an OCI registry (the default) or from a index.yaml-based repository ([#344]).

[#344]: https://github.com/stackabletech/stackable-cockpit/pull/344