### PR TITLE
fix: Use native CA certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.11.3"
+version = "24.11.4-native-certs"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7886,6 +7886,12 @@ rec {
             features = [ "std" "tls12" ];
           }
           {
+            name = "rustls-native-certs";
+            packageId = "rustls-native-certs";
+            optional = true;
+            target = { target, features }: (!("wasm32" == target."arch" or null));
+          }
+          {
             name = "rustls-pemfile";
             packageId = "rustls-pemfile";
             optional = true;
@@ -8052,7 +8058,7 @@ rec {
           "stream" = [ "tokio/fs" "dep:tokio-util" "dep:wasm-streams" ];
           "zstd" = [ "dep:async-compression" "async-compression?/zstd" "dep:tokio-util" ];
         };
-        resolvedDefaultFeatures = [ "__rustls" "__rustls-ring" "__tls" "blocking" "json" "rustls-tls" "rustls-tls-webpki-roots" ];
+        resolvedDefaultFeatures = [ "__rustls" "__rustls-ring" "__tls" "blocking" "json" "rustls-tls" "rustls-tls-native-roots" "rustls-tls-webpki-roots" ];
       };
       "ring" = rec {
         crateName = "ring";
@@ -9672,7 +9678,7 @@ rec {
             name = "reqwest";
             packageId = "reqwest";
             usesDefaultFeatures = false;
-            features = [ "json" "rustls-tls" ];
+            features = [ "json" "rustls-tls-native-roots" ];
           }
           {
             name = "semver";
@@ -10126,7 +10132,7 @@ rec {
             name = "reqwest";
             packageId = "reqwest";
             usesDefaultFeatures = false;
-            features = [ "json" "rustls-tls" ];
+            features = [ "json" "rustls-tls-native-roots" ];
           }
           {
             name = "semver";

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -10067,7 +10067,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.11.3";
+        version = "24.11.4-native-certs";
         edition = "2021";
         crateBin = [
           {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ phf = "0.11"
 phf_codegen = "0.11"
 rand = "0.8"
 regex = "1.10"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 rstest = "0.22"
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.11.3" 
+.TH stackablectl 1  "stackablectl 24.11.4-native-certs" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -108,6 +108,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.11.3
+v24.11.4\-native\-certs
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+- Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI ([#xxx]).
+
+[#xxx]: https://github.com/stackabletech/stackable-cockpit/pull/xxx
+
 ## [24.11.3] - 2025-01-27
 
 ### Added

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
-- Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI ([#xxx]).
+- Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI ([#351]).
 
-[#xxx]: https://github.com/stackabletech/stackable-cockpit/pull/xxx
+[#351]: https://github.com/stackabletech/stackable-cockpit/pull/351
 
 ## [24.11.3] - 2025-01-27
 

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.11.3"
+version = "24.11.4-native-certs"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI.

This is needed in the following cases:
- Internal mirrors of helm charts or stacks/demos signed by an internal CA.
- Firewalls that intercept HTTPS traffic.
