### PR TITLE
fix: Install correct operator version when using OCI registry 

### DIFF
--- a/rust/stackable-cockpit/src/constants.rs
+++ b/rust/stackable-cockpit/src/constants.rs
@@ -25,7 +25,7 @@ pub const HELM_REPO_INDEX_FILE: &str = "index.yaml";
 pub const HELM_OCI_BASE: &str = "oci.stackable.tech";
 pub const HELM_OCI_REGISTRY: &str = "oci://oci.stackable.tech/sdp-charts";
 
-pub const HELM_DEFAULT_CHART_VERSION: &str = ">0.0.0-0";
+pub const HELM_DEFAULT_CHART_VERSION: &str = "0.0.0-dev";
 
 pub const PRODUCT_NAMES: &[&str] = &[
     "airflow",


### PR DESCRIPTION
When installing any operator using

```bash
stackablectl operator install ...
```

without specifying the version or chart source, this command installed the latest stable version (in this case, 24.11.1). Instead, it should install the `0.0.0-dev` version when no exact version using `=...` is specified.

The issue boils down to different handling of versions / version constraints. If the user didn't provide a specific version, stackablectl defaulted to `>0.0.0-0`, which worked for index.yaml based repositories but installed the wrong version for OCI registries.

stackablectl now uses `0.0.0-dev` as the default. Both chart sources now behave as expected.