### PR TITLE
Adapt text about no prebuilt windows binaries to say "it is impossible"

### DIFF
--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -96,8 +96,13 @@ up asking if you want to allow access for `stackablectl`. You must allow access.
 Windows::
 +
 --
-Currently, there are no pre-built binaries available for Windows. Please refer to xref:#building-from-source[this]
-section to learn how to build the binary from source.
+Currently, there are no pre-built binaries available for Windows. At the time of writing this compiling `stackablectl` on
+Windows was impossible due to upstream bugs.
+While it may have become possible since then, it'll still provide significant challenges due to high technical complexity
+related to FFI, cgo and Windows-specific issues.
+
+If you do want to attempt it, please refer to xref:#building-from-source[this] section - and if you are successful, by
+all means, give us a shout and we will reward you handsomely!!
 --
 ====
 


### PR DESCRIPTION
# Description

Currently we insinuate that building stackablectl on Windows is possible, but we offer no pre-built binaries.
Last we looked, compiling stackablectl for Windows presented itself as effectively impossible (https://github.com/stackabletech/stackable-cockpit/issues/92#issuecomment-1746880974) - so we should say so in the docs.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Documentation added or updated
```
