### PR TITLE
fix(stackable-cockpit/stacklet): Use heritage label for looking up minio

### DIFF
--- a/rust/stackable-cockpit/src/platform/stacklet/minio.rs
+++ b/rust/stackable-cockpit/src/platform/stacklet/minio.rs
@@ -13,7 +13,7 @@ pub(super) async fn list(client: &Client, namespace: Option<&str>) -> Result<Vec
     let mut stacklets = Vec::new();
 
     // The helm-chart uses `app` instead of `app.kubernetes.io/app`, so we can't use `ListParams::from_product` here
-    let params = ListParams::default().labels("app=minio,app.kubernetes.io/managed-by=Helm");
+    let params = ListParams::default().labels("app=minio,heritage=Helm");
     let services = client
         .list_services(namespace, &params)
         .await

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 
 - Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI ([#351]).
+- Use `heritage` label when looking up the `minio-console` stacklet ([#364]).
 
 [#351]: https://github.com/stackabletech/stackable-cockpit/pull/351
+[#364]: https://github.com/stackabletech/stackable-cockpit/pull/364
 
 ## [24.11.3] - 2025-01-27
 


### PR DESCRIPTION
Fixes #363

# Description

Due to the minio charts being pre-rendered (until they can support TLS certs mounted directly on pods instead of via a Secret mount), the labels have slightly changed.

Therefore, stackable-cockpit needs to lookup a common label.

> [!TIP]
> Ideally we should have a new label that is applied to both `plainYaml` and `helmChart`, eg: `stackable.tech/stacklet: "true"` - but that is a little difficult without intercepting Helm Chart yamls.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Testing

24.11.1 demo:

```
┌──────────┬───────────────┬───────────┬─────────────────────────────────┬────────────────────────────────────────────┐
│ PRODUCT  ┆ NAME          ┆ NAMESPACE ┆ ENDPOINTS                       ┆ CONDITIONS                                 │
╞══════════╪═══════════════╪═══════════╪═════════════════════════════════╪════════════════════════════════════════════╡
│ minio    ┆ minio-console ┆ default   ┆ https  https://172.18.0.2:31131 ┆                                            │
└──────────┴───────────────┴───────────┴─────────────────────────────────┴────────────────────────────────────────────┘
```

nightly (pre-25.3.0) demo:

```
┌──────────┬───────────────┬───────────┬─────────────────────────────────┬────────────────────────────────────────────┐
│ PRODUCT  ┆ NAME          ┆ NAMESPACE ┆ ENDPOINTS                       ┆ CONDITIONS                                 │
╞══════════╪═══════════════╪═══════════╪═════════════════════════════════╪════════════════════════════════════════════╡
│ minio    ┆ minio-console ┆ default   ┆ http    http://172.18.0.2:31632 ┆                                            │
└──────────┴───────────────┴───────────┴─────────────────────────────────┴────────────────────────────────────────────┘
```