### PR TITLE
chore: Release stackablectl 25.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "24.11.4-native-certs"
+version = "25.3.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -10067,7 +10067,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "24.11.4-native-certs";
+        version = "25.3.0";
         edition = "2021";
         crateBin = [
           {

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -1,7 +1,7 @@
 = Installation
 :page-aliases: stable@stackablectl::installation.adoc
 
-:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-24.11.3
+:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-25.3.0
 :fish-comp-loations: https://fishshell.com/docs/current/completions.html#where-to-put-completions
 :nushell-comp-locations: https://www.nushell.sh/book/custom_commands.html#persisting
 
@@ -23,14 +23,14 @@ You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.11.3/stackablectl-x86_64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-25.3.0/stackablectl-x86_64-unknown-linux-gnu
 ----
 
 **aarch64** (arm64):
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.11.3/stackablectl-aarch64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-25.3.0/stackablectl-aarch64-unknown-linux-gnu
 ----
 
 Install the binary into a directory in the `$PATH`, and make it executable:
@@ -60,14 +60,14 @@ You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.11.3/stackablectl-x86_64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-25.3.0/stackablectl-x86_64-apple-darwin
 ----
 
 **aarch64** (arm64):
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-24.11.3/stackablectl-aarch64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-25.3.0/stackablectl-aarch64-apple-darwin
 ----
 
 Install the binary into a directory in the `$PATH`, and make it executable:

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 24.11.4-native-certs" 
+.TH stackablectl 1  "stackablectl 25.3.0" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -108,6 +108,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v24.11.4\-native\-certs
+v25.3.0
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [25.3.0] - 2025-03-27
+
 ### Fixes
 
 - Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI ([#351]).

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "24.11.4-native-certs"
+version = "25.3.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackablectl 25.3.0 which includes:

### Fixes

- Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI ([#351]).
- Use `heritage` label when looking up the `minio-console` stacklet ([#364]).
- Improve tracing and log output ([#365]).

[#351]: https://github.com/stackabletech/stackable-cockpit/pull/351
[#364]: https://github.com/stackabletech/stackable-cockpit/pull/364
[#365]: https://github.com/stackabletech/stackable-cockpit/pull/365