### PR TITLE
chore: Release stackablectl 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "25.3.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -11346,7 +11346,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "25.3.0";
+        version = "1.0.0";
         edition = "2021";
         crateBin = [
           {

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 25.3.0" 
+.TH stackablectl 1  "stackablectl 1.0.0" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -108,6 +108,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v25.3.0
+v1.0.0
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 - Prefix `ui-http` port endpoints with `http://`, as e.g. used by hbase-operator ([#368]).
 
+[#355]: https://github.com/stackabletech/stackable-cockpit/pull/355
 [#368]: https://github.com/stackabletech/stackable-cockpit/pull/368
 [#373]: https://github.com/stackabletech/stackable-cockpit/pull/373
 [#376]: https://github.com/stackabletech/stackable-cockpit/pull/376
@@ -38,7 +39,6 @@ All notable changes to this project will be documented in this file.
 - Improve tracing and log output ([#365]).
 
 [#351]: https://github.com/stackabletech/stackable-cockpit/pull/351
-[#355]: https://github.com/stackabletech/stackable-cockpit/pull/355
 [#364]: https://github.com/stackabletech/stackable-cockpit/pull/364
 [#365]: https://github.com/stackabletech/stackable-cockpit/pull/365
 

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0] - 2025-06-02
+
 ### Added
 
 - Pass the stack/demo namespace as a templating variable `NAMESPACE` to manifests.

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "25.3.0"
+version = "1.0.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackablectl **1.0.0**.

This is the **first** version released with the new versioning in place. Previously, the tool used the same versioning as our SDP releases, which lead to confusions, especially around patch-level releases. This is why we decided to use an independent versioning mechanism going forward.

### Added

- Pass the stack/demo namespace as a templating variable `NAMESPACE` to manifests.
  This should unblock demos to run in all namespaces, as they can template the namespace e.g. for the FQDN of services ([#355]).
- Add progress reporting ([#376]).
- Include SparkConnectServer in the `stacklet list` output ([#380]).
- Add release upgrade functionality to `stackablectl release` command through `upgrade` subcommand ([#379]).

### Changed

- Renamed `--product-namespace` argument to `--namespace` ([#373], [#355]).
  - Kept `--product-namespace` as a hidden alias to be removed in a later release.

### Fixed

- Prefix `ui-http` port endpoints with `http://`, as e.g. used by hbase-operator ([#368]).

[#355]: https://github.com/stackabletech/stackable-cockpit/pull/355
[#368]: https://github.com/stackabletech/stackable-cockpit/pull/368
[#373]: https://github.com/stackabletech/stackable-cockpit/pull/373
[#376]: https://github.com/stackabletech/stackable-cockpit/pull/376
[#380]: https://github.com/stackabletech/stackable-cockpit/pull/380
[#379]: https://github.com/stackabletech/stackable-cockpit/pull/379