### PR TITLE
ci: Bump Ubuntu runners

### DIFF
--- a/.github/workflows/pr_stackablectl.yml
+++ b/.github/workflows/pr_stackablectl.yml
@@ -38,9 +38,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin

--- a/.github/workflows/release_stackablectl.yml
+++ b/.github/workflows/release_stackablectl.yml
@@ -24,10 +24,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04 # We don't use ubuntu-latest because we want to build against an old glibc version. (18.04 has glibc 2.27, 20.04 has glibc 2.31, 22.04 has glibc 2.35)
+            os: ubuntu-24.04
             file-suffix: ""
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm # 2025-01: The ARM runners only support Ubuntu 22.04 or 24.04, so we can't pick 20.04:
+            os: ubuntu-24.04-arm
             file-suffix: ""
           - target: x86_64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
Part of #382.

During the release workflow, a job was cancelled because it used an outdated Ubuntu runner (20.04). All Ubuntu runners now use 24.04 instead.