### PR TITLE
chore: Release stackablectl 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -11985,7 +11985,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "1.0.0";
+        version = "1.1.0";
         edition = "2021";
         crateBin = [
           {

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 1.0.0" 
+.TH stackablectl 1  "stackablectl 1.1.0" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -110,6 +110,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v1.0.0
+v1.1.0
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-07-16
+
 ### Added
 
 - Add OpenSearch to the list of supported products ([#400]).

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "1.0.0"
+version = "1.1.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackablectl **1.1.0**.

### Added

- Add OpenSearch to the list of supported products ([#400]).

### Fixed

- nix: Update nixpkgs and upgrade nodejs-18 to nodejs_20 ([#384]).
- nix: Default to release build ([#388]).
- Switch to idempotent Helm installations for demos and stacks ([#386]).
- Ignore failed re-application of Jobs due to immutability in demo and stack installations.
  Display those manifests to the user, so they can decide if they need to delete and recreate it ([#386]).

[#384]: https://github.com/stackabletech/stackable-cockpit/pull/384
[#386]: https://github.com/stackabletech/stackable-cockpit/pull/386
[#388]: https://github.com/stackabletech/stackable-cockpit/pull/388
[#400]: https://github.com/stackabletech/stackable-cockpit/pull/400
