### PR TITLE
docs: Add release notes for stackablectl

### DIFF
--- a/docs/modules/stackablectl/nav.adoc
+++ b/docs/modules/stackablectl/nav.adoc
@@ -1,6 +1,7 @@
 * xref:index.adoc[stackablectl]
 ** xref:installation.adoc[Installation]
 ** xref:quickstart.adoc[Quickstart]
+** xref:release-notes.adoc[Release notes]
 ** xref:commands/index.adoc[Commands]
 *** xref:commands/cache.adoc[cache]
 *** xref:commands/completions.adoc[completions]

--- a/docs/modules/stackablectl/pages/release-notes.adoc
+++ b/docs/modules/stackablectl/pages/release-notes.adoc
@@ -5,6 +5,8 @@
 A full list of changes is available directly in https://github.com/stackabletech/stackable-cockpit/blob/main/rust/stackablectl/CHANGELOG.md[stackablectl's changelog].
 
 // WARNING: Please keep the empty newlines, otherwise headings are broken.
+include::partial$release-notes/release-1.1.0.adoc[]
+
 include::partial$release-notes/release-1.0.0.adoc[]
 
 include::partial$release-notes/releases-old.adoc[]

--- a/docs/modules/stackablectl/pages/release-notes.adoc
+++ b/docs/modules/stackablectl/pages/release-notes.adoc
@@ -1,0 +1,10 @@
+= Release notes for stackablectl
+:page-toclevels: 3
+:description: Learn about the latest features and changes in the release notes for stackablectl.
+
+A full list of changes is available directly in https://github.com/stackabletech/stackable-cockpit/blob/main/rust/stackablectl/CHANGELOG.md[stackablectl's changelog].
+
+// WARNING: Please keep the empty newlines, otherwise headings are broken.
+include::partial$release-notes/release-1.0.0.adoc[]
+
+include::partial$release-notes/releases-old.adoc[]

--- a/docs/modules/stackablectl/partials/release-notes/release-1.0.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.0.0.adoc
@@ -1,5 +1,12 @@
 == 1.0.0
 
+[NOTE]
+====
+Previously, `stackablectl` was release alongside each Stackable Data Platform (SDP) release.
+However, the patch releases from thereon were not related to SDP.
+We have since decided to version `stackablectl` independently of SDP, starting at 1.0.0.
+====
+
 * We have added visual progress reporting to more easily see what the tool is doing at any given moment in time.
   Previously, it looked like the tool was hanging as nothing was printed out to the terminal during the installation, but only after.
   See https://github.com/stackabletech/stackable-cockpit/pull/376[stackable-cockpit#376].

--- a/docs/modules/stackablectl/partials/release-notes/release-1.0.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.0.0.adoc
@@ -5,4 +5,4 @@
   See https://github.com/stackabletech/stackable-cockpit/pull/376[stackable-cockpit#376].
 * Releases can now be upgraded with the new `release upgrade` command.
   This makes it easier to upgrade installed operators to a newer SDP release.
-  See https://github.com/stackabletech/stackable-cockpit/pull/379[stackable-cokcpit#379].
+  See https://github.com/stackabletech/stackable-cockpit/pull/379[stackable-cockpit#379].

--- a/docs/modules/stackablectl/partials/release-notes/release-1.0.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.0.0.adoc
@@ -1,0 +1,8 @@
+== 1.0.0
+
+* We have added visual progress reporting to more easily see what the tool is doing at any given moment in time.
+  Previously, it looked like the tool was hanging as nothing was printed out to the terminal during the installation, but only after.
+  See https://github.com/stackabletech/stackable-cockpit/pull/376[stackable-cockpit#376].
+* Releases can now be upgraded with the new `release upgrade` command.
+  This makes it easier to upgrade installed operators to a newer SDP release.
+  See https://github.com/stackabletech/stackable-cockpit/pull/379[stackable-cokcpit#379].

--- a/docs/modules/stackablectl/partials/release-notes/release-1.1.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.1.0.adoc
@@ -5,3 +5,5 @@
 * Ignore failed re-application of Jobs due to immutability in demo and stack installations.
   The user is now asked if these be deleted or recreated.
   See https://github.com/stackabletech/stackable-cockpit/pull/386[stackable-cockpit#386].
+* Default to release build for nix users.
+  See https://github.com/stackabletech/stackable-cockpit/pull/388[stackable-cockpit#388].

--- a/docs/modules/stackablectl/partials/release-notes/release-1.1.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.1.0.adoc
@@ -1,7 +1,7 @@
 == 1.1.0
 
 * We now support idempotent Helm installations for demos and stacks.
-  See https://github.com/stackabletech/stackable-cockpit/pull/386[stackable-cokcpit#386].
+  See https://github.com/stackabletech/stackable-cockpit/pull/386[stackable-cockpit#386].
 * Ignore failed re-application of Jobs due to immutability in demo and stack installations.
   The user is now asked if these be deleted or recreated.
-  See https://github.com/stackabletech/stackable-cockpit/pull/386[stackable-cokcpit#386].
+  See https://github.com/stackabletech/stackable-cockpit/pull/386[stackable-cockpit#386].

--- a/docs/modules/stackablectl/partials/release-notes/release-1.1.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.1.0.adoc
@@ -1,0 +1,7 @@
+== 1.1.0
+
+* We now support idempotent Helm installations for demos and stacks.
+  See https://github.com/stackabletech/stackable-cockpit/pull/386[stackable-cokcpit#386].
+* Ignore failed re-application of Jobs due to immutability in demo and stack installations.
+  The user is now asked if these be deleted or recreated.
+  See https://github.com/stackabletech/stackable-cockpit/pull/386[stackable-cokcpit#386].

--- a/docs/modules/stackablectl/partials/release-notes/releases-old.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/releases-old.adoc
@@ -1,0 +1,31 @@
+== 25.3.0
+
+* A new demo called `jupyterhub-keycloak` was added and is available via `stackablectl`.
+  The JupyterHub-Keycloak integration demo offers a comprehensive and secure multi-user data science environment on Kubernetes, integrating Single Sign-on Jupyter notebooks with Stackable Spark and S3 storage.
+  The demo can be installed by running `stackablectl demo install jupyterhub-keycloak`.
+  See https://github.com/stackabletech/demos/pull/155[demos#155] and https://github.com/stackabletech/documentation/pull/715[documentation#715].
+* Demos and stacks are now versioned and the main branch is considered unstable.
+  `stackablectl` by default installs the latest stable demo and/or stack.
+  A specific release can be targeted by providing the `--release` argument.
+  See https://github.com/stackabletech/stackable-cockpit/pull/340[stackable-cockpit#340].
+* Add new argument --chart-source so that operator charts can be pulled either from an OCI registry (the default) or from a index.yaml-based repository.
+  See https://github.com/stackabletech/stackable-cockpit/pull/344[stackable-cockpit#344].
+* Use `rustls-native-certs` so that `stackablectl` can be used in environments with internal PKI.
+  See  https://github.com/stackabletech/stackable-cockpit/pull/351[stackable-cockpit#351].
+* Use `heritage` label when looking up the `minio-console` stacklet.
+  See https://github.com/stackabletech/stackable-cockpit/pull/364[stackable-cockpit#364].
+* Improve tracing and log output.
+  See https://github.com/stackabletech/stackable-cockpit/pull/365[stackable-cockpit#365].
+
+== 24.11.0
+
+* Bump Rust dependencies to fix critical vulnerability in quinn-proto.
+  See https://github.com/advisories/GHSA-vr26-jcq5-fjj8[CVE-2024-45311] and https://github.com/stackabletech/stackable-cockpit/pull/318[stackable-cockpit#318].
+* We now provide additional completions for Nushell and Elvish, support using SOCK5 and HTTP proxies, and have improved the sorting of release versions.
+
+== 24.7.0
+
+* a new experimental debug command
+* a pre-built binary for aarch64-unknown-linux-gnu is now available
+* complete error messages are now shown (remedying the truncation of some details in previous releases)
+* use of the latest Go and Rust versions and respective dependencies


### PR DESCRIPTION
Part of https://github.com/stackabletech/documentation/pull/757

This adds separate release notes for `stackablectl`.