### PR TITLE
fix: set current stackablectl release to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
-version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
@@ -3102,7 +3101,7 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
+]:
 
 [[package]]
 name = "rustls-native-certs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,7 +3101,7 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]:
+]
 
 [[package]]
 name = "rustls-native-certs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3154,9 +3154,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -10505,9 +10505,9 @@ rec {
       };
       "rustls-webpki" = rec {
         crateName = "rustls-webpki";
-        version = "0.103.10";
+        version = "0.103.11";
         edition = "2021";
-        sha256 = "1vyipcdbazvhl6kyi1m8n0bg98sk25iv12bby2xcly653awb4cyz";
+        sha256 = "1m3wpj1sfnpgwd6692lf42bcjsk6mbl6dwgarkn20jzadx8sz9i0";
         libName = "webpki";
         dependencies = [
           {

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -1,7 +1,7 @@
 = Installation
 :page-aliases: stable@stackablectl::installation.adoc
 
-:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-1.2.1
+:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-1.4.0
 :fish-comp-loations: https://fishshell.com/docs/current/completions.html#where-to-put-completions
 :nushell-comp-locations: https://www.nushell.sh/book/custom_commands.html#persisting
 
@@ -23,14 +23,14 @@ You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-x86_64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.4.0/stackablectl-x86_64-unknown-linux-gnu
 ----
 
 **aarch64** (arm64):
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-aarch64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.4.0/stackablectl-aarch64-unknown-linux-gnu
 ----
 
 Install the binary into a directory in the `$PATH`, and make it executable:
@@ -60,14 +60,14 @@ You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-x86_64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.4.0/stackablectl-x86_64-apple-darwin
 ----
 
 **aarch64** (arm64):
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-aarch64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.4.0/stackablectl-aarch64-apple-darwin
 ----
 
 Install the binary into a directory in the `$PATH`, and make it executable:


### PR DESCRIPTION
# Description

The download links for `stackablectl` in the documentation pointed to an old version.