### PR TITLE
docs: Add missing release notes for stackablectl

### DIFF
--- a/docs/modules/stackablectl/pages/release-notes.adoc
+++ b/docs/modules/stackablectl/pages/release-notes.adoc
@@ -6,6 +6,12 @@ A full list of changes is available directly in https://github.com/stackabletech
 
 // WARNING: Please keep the empty newlines, otherwise headings are broken.
 
+include::partial$release-notes/release-1.4.0.adoc[]
+
+include::partial$release-notes/release-1.3.0.adoc[]
+
+include::partial$release-notes/release-1.2.2.adoc[]
+
 include::partial$release-notes/release-1.2.1.adoc[]
 
 include::partial$release-notes/release-1.2.0.adoc[]

--- a/docs/modules/stackablectl/partials/release-notes/release-1.3.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.3.0.adoc
@@ -1,0 +1,8 @@
+== 1.3.0
+
+* Allow specifying Helm values for operator installations.
+  See https://github.com/stackabletech/stackable-cockpit/pull/425[stackable-cockpit#425].
+* Bump Rust to `1.93.0` as well as dependencies.
+  See https://github.com/stackabletech/stackable-cockpit/pull/426[stackable-cockpit#426].
+* Bump Go to `1.26.0` as well as dependencies.
+  See https://github.com/stackabletech/stackable-cockpit/pull/426[stackable-cockpit#426].

--- a/docs/modules/stackablectl/partials/release-notes/release-1.4.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.4.0.adoc
@@ -1,0 +1,4 @@
+== 1.4.0
+
+* Add `STACK` and `DEMO` templating parameters. Have a look at the `README.md` for details.
+  See https://github.com/stackabletech/stackable-cockpit/pull/432[stackable-cockpit#432].

--- a/rust/stackablectl/RELEASE.md
+++ b/rust/stackablectl/RELEASE.md
@@ -6,10 +6,12 @@ to be done:
 1. Ensure your local `main` branch is up-to-date and then proceed to checkout a new branch using
    `git checkout -b chore/release-stackablectl-X.Y.Z`.
 2. Update both the Cargo.toml and CHANGELOG.md file to the new version `X.Y.Z`.
-3. Update various files by running the following xtask `cargo xtask gen-man` and
+3. Add the relevant changes from the changelog to a new release notes partial under
+   `docs/stackablectl/partials/release-notes`.
+4. Update various files by running the following xtask `cargo xtask gen-man` and
    `make regenerate-nix`. This is also automatically done if pre-commit is enabled.
-4. Push the changes and raise a PR.
-5. Merge the PR onto `main` and then proceed to tag the appropriate commit using
+5. Push the changes and raise a PR.
+6. Merge the PR onto `main` and then proceed to tag the appropriate commit using
    `git tag -s stackablectl-Y.Y.Z -m stackablectl-Y.Y.Z`.
-6. Building the artifacts and creating the release on GitHub is fully automated from this point
+7. Building the artifacts and creating the release on GitHub is fully automated from this point
    onward.


### PR DESCRIPTION
This PR adds the release notes for 1.3.0 and 1.4.0 and includes them on the release notes page. Additionally, the 1.2.2 release notes (which were already present) are now also included.