### PR TITLE
chore: Add script to verify release notes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,8 +103,16 @@ repos:
 
       - id: cargo-rustfmt
         name: cargo-rustfmt
+        files: \.rs$
         language: system
         # Pinning to a specific rustc version, so that we get consistent formatting
         entry: cargo +nightly-2025-05-26 fmt --all -- --check
         stages: [pre-commit]
+        pass_filenames: false
+
+      - id: ./scripts/verify_release_notes
+        name: ./scripts/verify_release_notes
+        language: system
+        entry: ./scripts/verify_release_notes.sh
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false

--- a/scripts/verify_release_notes.sh
+++ b/scripts/verify_release_notes.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+STACKABLECTL_VERSION=$(grep 'version' "./rust/stackablectl/Cargo.toml" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+[ -n "$STACKABLECTL_VERSION" ] || (
+    echo "CRATE_VERSION for is empty." >&2
+    echo "Please check ./rust/stackablectl/Cargo.toml" >&2
+    exit 1
+)
+
+RELEASE_NOTES_FILE="./docs/modules/stackablectl/partials/release-notes/release-${STACKABLECTL_VERSION}.adoc"
+
+if [ ! -f "$RELEASE_NOTES_FILE" ]; then
+    echo "$RELEASE_NOTES_FILE does not exist, please create it and add the appropriate content" >&2
+    exit 1
+fi


### PR DESCRIPTION
This PR adds a script to verify that a release notes partial exists for the current stackablectl version specified via Cargo.toml.